### PR TITLE
fix: bSDD auth redirect URI, client ID, and X-User-Agent header

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,9 +47,11 @@ jobs:
           VITE_APP_VERSION: ${{ github.ref == 'refs/heads/main' && env.VITE_APP_VERSION || github.ref_name }}
           # Client ID is a public SPA client (no secret) — embedded here for convenience.
           # Override with a GitHub secret if you register a separate app per environment.
-          VITE_BSDD_CLIENT_ID: '0fcd615b-f2b7-4514-9046-7b3e545ba341'
+          VITE_BSDD_CLIENT_ID: 'ba6a70eb-8e2d-4caa-ae3d-22fc1765c0a5'
           # Production scope — override with VITE_BSDD_SCOPE secret for test deployments
           VITE_BSDD_SCOPE: 'https://buildingSMARTservices.onmicrosoft.com/bsddapi/read'
+          # Fixed redirect URI — all versioned deployments share this one registered URI
+          VITE_BSDD_REDIRECT_URI: 'https://buildingsmart-community.github.io/bSDD-filter-UI/'
         run: |
           yarn install
           yarn run build
@@ -80,3 +82,41 @@ jobs:
           folder: dist
           target-folder: ${{ github.ref_name }}
           clean: true
+
+      - name: Create MSAL redirect handler
+        if: github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p redirect-root
+          cat > redirect-root/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html>
+            <head><title>bSDD filter UI</title></head>
+            <body>
+              <script src="https://alcdn.msauth.net/browser/5.9.0/js/msal-browser.min.js"></script>
+              <script>
+                // Handles the MSAL redirect flow. After B2C redirects here, MSAL
+                // processes the auth code and navigates back to the versioned app
+                // URL stored in sessionStorage (navigateToLoginRequestUrl: true).
+                (async () => {
+                  const app = new msal.PublicClientApplication({
+                    auth: {
+                      clientId: 'ba6a70eb-8e2d-4caa-ae3d-22fc1765c0a5',
+                      redirectUri: window.location.href.split('?')[0].split('#')[0],
+                    },
+                  });
+                  await app.initialize();
+                  await app.handleRedirectPromise();
+                })();
+              </script>
+            </body>
+          </html>
+          EOF
+
+      - name: Deploy MSAL redirect handler to root
+        if: github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          branch: gh-pages
+          folder: redirect-root
+          target-folder: .
+          clean: false

--- a/shared/bsdd-api/BsddApiWrapper.ts
+++ b/shared/bsdd-api/BsddApiWrapper.ts
@@ -568,7 +568,7 @@ export class BsddApiWrapper {
         if (isTest) formData.append('IsTest', 'true')
 
         const headers: Record<string, string> = {
-          'X-Client-Name': this.transport.getUserAgent(),
+          'X-User-Agent': this.transport.getUserAgent(),
         }
         if (accessToken) headers['Authorization'] = `Bearer ${accessToken}`
 
@@ -665,7 +665,7 @@ export class BsddApiWrapper {
       if (isTest) formData.append('IsTest', 'true')
 
       const headers: Record<string, string> = {
-        'X-Client-Name': this.transport.getUserAgent(),
+        'X-User-Agent': this.transport.getUserAgent(),
       }
       if (accessToken) headers['Authorization'] = `Bearer ${accessToken}`
 

--- a/src/auth/authConfig.ts
+++ b/src/auth/authConfig.ts
@@ -4,7 +4,7 @@ import type { Configuration, PopupRequest } from '@azure/msal-browser';
 // buildingSMART Azure AD B2C configuration.
 // Client ID is a public SPA client (no secret) — safe to embed in source.
 // Override via .env for local development with a different registration.
-const BSDD_CLIENT_ID = import.meta.env.VITE_BSDD_CLIENT_ID || '0fcd615b-f2b7-4514-9046-7b3e545ba341';
+const BSDD_CLIENT_ID = import.meta.env.VITE_BSDD_CLIENT_ID || 'ba6a70eb-8e2d-4caa-ae3d-22fc1765c0a5';
 const BSDD_AUTHORITY =
   import.meta.env.VITE_BSDD_AUTHORITY ||
   'https://buildingsmartservices.b2clogin.com/buildingsmartservices.onmicrosoft.com/B2C_1_SignUpSignIn';
@@ -15,6 +15,11 @@ const BSDD_KNOWN_AUTHORITY = import.meta.env.VITE_BSDD_KNOWN_AUTHORITY || 'build
 // Test:       'https://buildingSMARTservices.onmicrosoft.com/api/read'
 const BSDD_SCOPE = import.meta.env.VITE_BSDD_SCOPE || 'https://buildingSMARTservices.onmicrosoft.com/bsddapi/read';
 
+// Redirect URI for MSAL. Set VITE_BSDD_REDIRECT_URI to a fixed base path (e.g.
+// 'https://buildingsmart-community.github.io/bSDD-filter-UI/') so all versioned
+// deployments share one registered URI. Falls back to origin for local dev.
+const BSDD_REDIRECT_URI = import.meta.env.VITE_BSDD_REDIRECT_URI || window.location.origin;
+
 // Check if bSDD auth is configured (client ID must be set)
 export const isBsddAuthConfigured = (): boolean => Boolean(BSDD_CLIENT_ID);
 
@@ -23,8 +28,8 @@ export const msalConfig: Configuration = {
     clientId: BSDD_CLIENT_ID || 'not-configured',
     authority: BSDD_AUTHORITY,
     knownAuthorities: [BSDD_KNOWN_AUTHORITY],
-    redirectUri: window.location.origin,
-    postLogoutRedirectUri: window.location.origin,
+    redirectUri: BSDD_REDIRECT_URI,
+    postLogoutRedirectUri: BSDD_REDIRECT_URI,
   },
   cache: {
     cacheLocation: 'localStorage',


### PR DESCRIPTION
## Changes

- **New client ID** set in `authConfig.ts` and the MSAL redirect handler
- **Fixed redirect URI**: `VITE_BSDD_REDIRECT_URI` set to `https://buildingsmart-community.github.io/bSDD-filter-UI/` in CI — one registered URI covers all versioned deployments
- **MSAL redirect handler**: minimal `index.html` deployed to the GitHub Pages root on main-branch pushes; handles `loginRedirect` flow and bounces users back to their versioned app via MSAL's `navigateToLoginRequestUrl`
- **`X-User-Agent` header**: renamed from `X-Client-Name` to match [bSDD API docs](https://github.com/buildingSMART/bSDD/blob/master/Documentation/bSDD%20API.md) requirement