### PR TITLE
fix: MSAL redirect handler — ESM import, single gh-pages push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,14 +56,43 @@ jobs:
           yarn install
           yarn run build
 
+      - name: Prepare deploy folder (main)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p deploy-main/main
+          cp -r dist/. deploy-main/main/
+          cat > deploy-main/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html>
+            <head><title>bSDD filter UI</title></head>
+            <body>
+              <script type="module">
+                // Handles the MSAL redirect flow. After B2C redirects here, MSAL
+                // processes the auth code and navigates back to the versioned app
+                // URL stored in sessionStorage (navigateToLoginRequestUrl: true).
+                // Uses ESM import — MSAL v5 no longer ships a UMD/global bundle.
+                import { PublicClientApplication } from 'https://cdn.jsdelivr.net/npm/@azure/msal-browser@5/+esm';
+                const app = new PublicClientApplication({
+                  auth: {
+                    clientId: 'ba6a70eb-8e2d-4caa-ae3d-22fc1765c0a5',
+                    redirectUri: window.location.href.split('?')[0].split('#')[0],
+                  },
+                });
+                await app.initialize();
+                await app.handleRedirectPromise();
+              </script>
+            </body>
+          </html>
+          EOF
+
       - name: Deploy to GitHub Pages (main)
         if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           branch: gh-pages
-          folder: dist
-          target-folder: main
-          clean: true
+          folder: deploy-main
+          target-folder: .
+          clean: false
 
       - name: Deploy to GitHub Pages (latest release)
         if: startsWith(github.ref, 'refs/tags/')
@@ -82,41 +111,3 @@ jobs:
           folder: dist
           target-folder: ${{ github.ref_name }}
           clean: true
-
-      - name: Create MSAL redirect handler
-        if: github.ref == 'refs/heads/main'
-        run: |
-          mkdir -p redirect-root
-          cat > redirect-root/index.html << 'EOF'
-          <!DOCTYPE html>
-          <html>
-            <head><title>bSDD filter UI</title></head>
-            <body>
-              <script src="https://alcdn.msauth.net/browser/5.9.0/js/msal-browser.min.js"></script>
-              <script>
-                // Handles the MSAL redirect flow. After B2C redirects here, MSAL
-                // processes the auth code and navigates back to the versioned app
-                // URL stored in sessionStorage (navigateToLoginRequestUrl: true).
-                (async () => {
-                  const app = new msal.PublicClientApplication({
-                    auth: {
-                      clientId: 'ba6a70eb-8e2d-4caa-ae3d-22fc1765c0a5',
-                      redirectUri: window.location.href.split('?')[0].split('#')[0],
-                    },
-                  });
-                  await app.initialize();
-                  await app.handleRedirectPromise();
-                })();
-              </script>
-            </body>
-          </html>
-          EOF
-
-      - name: Deploy MSAL redirect handler to root
-        if: github.ref == 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
-        with:
-          branch: gh-pages
-          folder: redirect-root
-          target-folder: .
-          clean: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
                 // processes the auth code and navigates back to the versioned app
                 // URL stored in sessionStorage (navigateToLoginRequestUrl: true).
                 // Uses ESM import — MSAL v5 no longer ships a UMD/global bundle.
-                import { PublicClientApplication } from 'https://cdn.jsdelivr.net/npm/@azure/msal-browser@5/+esm';
+                import { PublicClientApplication } from 'https://cdn.jsdelivr.net/npm/@azure/msal-browser@5.9.0/+esm';
                 const app = new PublicClientApplication({
                   auth: {
                     clientId: 'ba6a70eb-8e2d-4caa-ae3d-22fc1765c0a5',
@@ -92,7 +92,10 @@ jobs:
           branch: gh-pages
           folder: deploy-main
           target-folder: .
-          clean: false
+          clean: true
+          clean-exclude: |
+            v[0-9]*
+            latest
 
       - name: Deploy to GitHub Pages (latest release)
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Bug fixes

### `msal is not defined` on redirect page
MSAL v5 no longer ships a UMD bundle, so `window.msal` is undefined. Replaced the CDN `<script src>` + `new msal.PublicClientApplication()` with an ESM `import` via jsDelivr.

### Double `pages-build-deployment` run
The previous approach made two separate `gh-pages` branch pushes on main (one for `main/`, one for the root handler), triggering two Pages build runs. Now a single `deploy-main/` folder is assembled containing both the root `index.html` and the `main/` subfolder, deployed in one push.