### PR TITLE
perf(rate-limit): align transport floors with bSDD's actual tiers

### DIFF
--- a/shared/bsdd-api/BsddApiClient.ts
+++ b/shared/bsdd-api/BsddApiClient.ts
@@ -72,7 +72,9 @@ export class BsddApiClient {
     const next = authenticated ? this.authenticatedMinDelay : this.unauthenticatedMinDelay;
     if (next === this.minDelay) return;
     this.minDelay = next;
-    this.adaptiveMinDelay = Math.max(next, Math.min(this.adaptiveMinDelay, this.adaptiveMaxDelay));
+    // Reset adaptive to the new tier's baseline — the prior backoff was for a
+    // different rate ceiling, so carrying it forward would penalise the new tier.
+    this.adaptiveMinDelay = next;
   }
 
   get baseURL(): string {

--- a/shared/bsdd-api/BsddApiClient.ts
+++ b/shared/bsdd-api/BsddApiClient.ts
@@ -3,7 +3,10 @@
 
 interface BsddApiClientConfig {
   baseURL?: string;
+  /** Floor between requests when unauthenticated. Defaults to 200 ms (10 calls/2s per IP). */
   minDelay?: number;
+  /** Floor between requests when authenticated. Defaults to 100 ms (30 calls/2s per user, with margin). */
+  authenticatedMinDelay?: number;
   appName?: string;
   appVersion?: string;
 }
@@ -29,7 +32,11 @@ const delay = (ms: number): Promise<void> =>
 export class BsddApiClient {
   private readonly _baseURL: string;
   private lastCallTime = 0;
-  private readonly minDelay: number;
+  // Active floor — swapped by setAuthenticated based on auth state.
+  // Per buildingSMART (2026-05-06): unauth 10 calls/2s/IP, auth 30 calls/2s/user.
+  private minDelay: number;
+  private readonly unauthenticatedMinDelay: number;
+  private readonly authenticatedMinDelay: number;
   private readonly appName: string;
   private readonly appVersion: string;
 
@@ -48,10 +55,24 @@ export class BsddApiClient {
 
   constructor(config: BsddApiClientConfig = {}) {
     this._baseURL = config.baseURL ?? 'https://api.bsdd.buildingsmart.org';
-    this.minDelay = config.minDelay ?? 1_000;
+    this.unauthenticatedMinDelay = config.minDelay ?? 200;
+    this.authenticatedMinDelay = config.authenticatedMinDelay ?? 100;
+    this.minDelay = this.unauthenticatedMinDelay;
     this.appName = config.appName ?? 'bsdd-filter-ui';
     this.appVersion = config.appVersion ?? '1.0.0';
     this.adaptiveMinDelay = this.minDelay;
+  }
+
+  /**
+   * Switch the floor between authenticated and anonymous tiers.
+   * Authenticated users get a 3× higher rate ceiling per buildingSMART.
+   * Resets the adaptive floor to the new baseline; backoff re-grows on 429.
+   */
+  setAuthenticated(authenticated: boolean): void {
+    const next = authenticated ? this.authenticatedMinDelay : this.unauthenticatedMinDelay;
+    if (next === this.minDelay) return;
+    this.minDelay = next;
+    this.adaptiveMinDelay = Math.max(next, Math.min(this.adaptiveMinDelay, this.adaptiveMaxDelay));
   }
 
   get baseURL(): string {

--- a/src/BsddCombinedLoader.tsx
+++ b/src/BsddCombinedLoader.tsx
@@ -1,6 +1,6 @@
 import { Container, Group, Modal, Paper, Space, Tabs } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAuthToken } from './auth/useAuthToken';
@@ -23,7 +23,16 @@ function BsddCombinedLoader() {
   const setSavedPropertyIsInstanceMap = useIfcDataStore((s) => s.setSavedPropertyIsInstanceMap);
 
   const [opened, { open, close }] = useDisclosure(false);
-  const { onSave, onCancel } = useBrowserBridge();
+  const { onSave: bridgeOnSave, onCancel } = useBrowserBridge();
+
+  const onSave = useCallback(
+    (bsddBridgeData: Parameters<typeof bridgeOnSave>[0]) =>
+      bridgeOnSave(bsddBridgeData).then((result) => {
+        close();
+        return result;
+      }),
+    [bridgeOnSave, close],
+  );
   const accessToken = useAuthToken();
   const [activeTab, setActiveTab] = useState(defaultTab);
   const [searchKey, setSearchKey] = useState<keyof IfcEntity | undefined>();

--- a/src/BsddCombinedLoader.tsx
+++ b/src/BsddCombinedLoader.tsx
@@ -23,7 +23,7 @@ function BsddCombinedLoader() {
   const setSavedPropertyIsInstanceMap = useIfcDataStore((s) => s.setSavedPropertyIsInstanceMap);
 
   const [opened, { open, close }] = useDisclosure(false);
-  const { onSave: bridgeOnSave, onCancel } = useBrowserBridge();
+  const { onSave: bridgeOnSave, onCancel: bridgeOnCancel } = useBrowserBridge();
 
   const onSave = useCallback(
     (bsddBridgeData: Parameters<typeof bridgeOnSave>[0]) =>
@@ -33,6 +33,11 @@ function BsddCombinedLoader() {
       }),
     [bridgeOnSave, close],
   );
+
+  const onCancel = useCallback(() => {
+    close();
+    return bridgeOnCancel();
+  }, [bridgeOnCancel, close]);
   const accessToken = useAuthToken();
   const [activeTab, setActiveTab] = useState(defaultTab);
   const [searchKey, setSearchKey] = useState<keyof IfcEntity | undefined>();

--- a/src/lib/api/bsddApiInstance.ts
+++ b/src/lib/api/bsddApiInstance.ts
@@ -1,4 +1,5 @@
 // Purpose: bSDD API client entry — re-exports the shared rate-limited transport and generated client
+import { bsddTransport } from '../../../shared/bsdd-api/BsddApiClient';
 import { client } from '../../../shared/bsdd-api/generated/client.gen';
 
 export { client as bsddHeyApiClient } from '../../../shared/bsdd-api/generated/client.gen';
@@ -21,6 +22,7 @@ let _accessToken: string | undefined;
 
 export const setBsddAccessToken = (token: string | undefined): void => {
   _accessToken = token;
+  bsddTransport.setAuthenticated(!!token);
 };
 
 // Inject Authorization header on every request when a token is available.

--- a/src/lib/api/hooks/useDictionaries.ts
+++ b/src/lib/api/hooks/useDictionaries.ts
@@ -3,12 +3,17 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchAllDictionaries, fetchDictionaryByUri } from '../fetchers/dictionaries';
 import { bsddKeys } from '../queryKeys';
 
+// Dictionary listings change rarely; match the IndexedDB persister's 24h TTL
+// so warm reloads serve from cache instead of refetching the full paginated list.
+const DICTIONARY_STALE_MS = 1000 * 60 * 60 * 24;
+const DICTIONARY_GC_MS = 1000 * 60 * 60 * 24;
+
 export function useDictionaries(includeTest?: boolean) {
   return useQuery({
     queryKey: bsddKeys.dictionaries(includeTest),
     queryFn: () => fetchAllDictionaries(includeTest),
-    staleTime: 1000 * 60 * 60, // 1 hour - dictionaries change rarely
-    gcTime: 1000 * 60 * 60 * 24, // 24 hours
+    staleTime: DICTIONARY_STALE_MS,
+    gcTime: DICTIONARY_GC_MS,
   });
 }
 
@@ -16,8 +21,8 @@ export function useDictionary(uri: string | undefined | null) {
   return useQuery({
     queryKey: bsddKeys.dictionary(uri!),
     queryFn: () => fetchDictionaryByUri(uri!),
-    staleTime: 1000 * 60 * 60,
-    gcTime: 1000 * 60 * 60 * 24,
+    staleTime: DICTIONARY_STALE_MS,
+    gcTime: DICTIONARY_GC_MS,
     enabled: !!uri,
   });
 }


### PR DESCRIPTION
Previous floor of 1000ms was 5x slower than the anonymous per-IP ceiling and ~15x slower than the authenticated per-user ceiling.

- BsddApiClient: default minDelay 1000 -> 200ms (unauth), with a new setAuthenticated(boolean) that drops the floor to 100ms when a token is present. Adaptive doubling on 429 stays as the safety net.
- bsddApiInstance: setBsddAccessToken now also toggles the transport's authenticated state, so the limiter tracks auth automatically.
- useDictionaries: staleTime 1h -> 24h to match the IndexedDB persister TTL; dictionary listings change rarely.

Slicer fill (many Class/v1 lookups) and selected-class detail fetch both come down by the same factor.