### PR TITLE
fix: dedicated bSDD client ID, preserve URL across MSAL logout

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,6 +3,6 @@ VITE_BSDD_ENVIRONMENT=https://test.bsdd.buildingsmart.org
 
 # bSDD Azure AD B2C authentication
 # Client ID from buildingSMART's app registration
-VITE_BSDD_CLIENT_ID=0fcd615b-f2b7-4514-9046-7b3e545ba341
+VITE_BSDD_CLIENT_ID=ba6a70eb-8e2d-4caa-ae3d-22fc1765c0a5
 VITE_BSDD_AUTHORITY=https://authentication.buildingsmart.org/tfp/buildingsmartservices.onmicrosoft.com/b2c_1a_signupsignin_c
 VITE_BSDD_KNOWN_AUTHORITY=authentication.buildingsmart.org

--- a/.env.production
+++ b/.env.production
@@ -2,6 +2,6 @@ VITE_APP_VERSION=development
 VITE_BSDD_ENVIRONMENT=https://api.bsdd.buildingsmart.org
 
 # bSDD Azure AD B2C authentication
-VITE_BSDD_CLIENT_ID=0fcd615b-f2b7-4514-9046-7b3e545ba341
+VITE_BSDD_CLIENT_ID=ba6a70eb-8e2d-4caa-ae3d-22fc1765c0a5
 VITE_BSDD_AUTHORITY=https://authentication.buildingsmart.org/tfp/buildingsmartservices.onmicrosoft.com/b2c_1a_signupsignin_c
 VITE_BSDD_KNOWN_AUTHORITY=authentication.buildingsmart.org

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,9 @@ jobs:
                   await app.initialize();
                   const result = await app.handleRedirectPromise();
                   if (!result) {
-                    window.location.replace('/bSDD-filter-UI/main/');
+                    const returnTo = sessionStorage.getItem('bsdd.postLogoutReturnTo');
+                    sessionStorage.removeItem('bsdd.postLogoutReturnTo');
+                    window.location.replace(returnTo || '/bSDD-filter-UI/main/');
                   }
                 } catch {
                   window.location.replace('/bSDD-filter-UI/main/');

--- a/src/auth/useAuth.ts
+++ b/src/auth/useAuth.ts
@@ -53,8 +53,19 @@ export const useAuth = (): UseAuthResult => {
     setIsLoading(true);
     setError(null);
 
+    // Store path-only (pathname+search+hash) so the redirect handler can return
+    // here. Isolated try/catch: storage failures (quota, private mode) must not
+    // block the logout — the app will just fall back to the default redirect URI.
     try {
-      sessionStorage.setItem('bsdd.postLogoutReturnTo', window.location.href);
+      sessionStorage.setItem(
+        'bsdd.postLogoutReturnTo',
+        window.location.pathname + window.location.search + window.location.hash,
+      );
+    } catch {
+      // Storage unavailable — logout proceeds, return-URL restore is skipped.
+    }
+
+    try {
       await instance.logoutRedirect();
     } catch (err) {
       console.error('bSDD logout error:', err);

--- a/src/auth/useAuth.ts
+++ b/src/auth/useAuth.ts
@@ -54,6 +54,7 @@ export const useAuth = (): UseAuthResult => {
     setError(null);
 
     try {
+      sessionStorage.setItem('bsdd.postLogoutReturnTo', window.location.href);
       await instance.logoutRedirect();
     } catch (err) {
       console.error('bSDD logout error:', err);


### PR DESCRIPTION
- Update VITE_BSDD_CLIENT_ID to the dedicated app registration for bSDD-filter-UI, replacing the repurposed Sketchup SKC downloader client.
- Save window.location.href to sessionStorage before logoutRedirect() and restore it in the MSAL redirect handler. Standard SPA pattern when postLogoutRedirectUri must be a registered URI (can't register every URL+query-param combination); MSAL uses sessionStorage internally for the same reason.