### PR TITLE
fix: pass through unresolvable classification references instead of dropping

### DIFF
--- a/src/lib/api/validation/validateIfcData.test.ts
+++ b/src/lib/api/validation/validateIfcData.test.ts
@@ -42,13 +42,12 @@ describe('patchIfcClassificationReference', () => {
     expect(fetchClasses).not.toHaveBeenCalled();
   });
 
-  it('returns invalid when no location and no referencedSource location', async () => {
-    const result = await patchIfcClassificationReference(
-      { type: 'IfcClassificationReference', name: 'X' } as any,
-      makeClient(),
-      'en-GB',
-    );
-    expect(result.validationState).toBe('invalid');
+  it('passes through unchanged when no location and no referencedSource location', async () => {
+    const ref = { type: 'IfcClassificationReference', name: 'X' } as any;
+    const result = await patchIfcClassificationReference(ref, makeClient(), 'en-GB');
+    expect(result.validationState).toBe('valid');
+    expect(result.ifcClassificationReference).toBe(ref);
+    expect(fetchClasses).not.toHaveBeenCalled();
   });
 
   it('fixes a reference by matching identification against fetched classes and re-resolving the dictionary', async () => {
@@ -81,19 +80,17 @@ describe('patchIfcClassificationReference', () => {
     expect(fetchDictionary).toHaveBeenCalled();
   });
 
-  it('reports invalid when the fetcher returns no matching class', async () => {
+  it('passes through unchanged when the fetcher returns no matching class', async () => {
     fetchClasses.mockResolvedValue([{ code: 'OTHER', name: 'Other', uri: 'https://x' }]);
-    const result = await patchIfcClassificationReference(
-      {
-        type: 'IfcClassificationReference',
-        identification: 'nope',
-        name: 'Nope',
-        referencedSource: { type: 'IfcClassification', location: 'https://example.org/dict' } as any,
-      } as any,
-      makeClient(),
-      'en-GB',
-    );
-    expect(result.validationState).toBe('invalid');
+    const ref = {
+      type: 'IfcClassificationReference',
+      identification: 'nope',
+      name: 'Nope',
+      referencedSource: { type: 'IfcClassification', location: 'https://example.org/dict' } as any,
+    } as any;
+    const result = await patchIfcClassificationReference(ref, makeClient(), 'en-GB');
+    expect(result.validationState).toBe('valid');
+    expect(result.ifcClassificationReference).toBe(ref);
   });
 });
 
@@ -132,20 +129,15 @@ describe('validateIfcData', () => {
     expect(result[0].isDefinedBy?.[0].hasProperties).toHaveLength(2);
   });
 
-  it('drops invalid IfcClassificationReference associations', async () => {
+  it('passes through unresolvable IfcClassificationReference associations unchanged', async () => {
+    const ref = { type: 'IfcClassificationReference', name: 'Bad' } as any;
     const result = await validateIfcData(
-      [
-        {
-          type: 'IfcWall',
-          hasAssociations: [
-            { type: 'IfcClassificationReference', name: 'Bad' } as any, // missing location and referencedSource
-          ],
-        },
-      ],
+      [{ type: 'IfcWall', hasAssociations: [ref] }],
       makeClient(),
       'en-GB',
     );
-    expect(result[0].hasAssociations).toEqual([]);
+    expect(result[0].hasAssociations).toHaveLength(1);
+    expect(result[0].hasAssociations?.[0]).toEqual(ref);
   });
 
   it('passes through IfcMaterial associations untouched', async () => {

--- a/src/lib/api/validation/validateIfcData.ts
+++ b/src/lib/api/validation/validateIfcData.ts
@@ -18,7 +18,7 @@ import { convertBsddDictionaryToIfcClassification } from '../../common/IfcData/i
 import { fetchAllDictionaryClasses, fetchDictionaryByUri } from '../fetchers/dictionaries';
 import { bsddKeys } from '../queryKeys';
 
-type ValidationState = 'valid' | 'invalid' | 'fixed';
+type ValidationState = 'valid' | 'fixed';
 
 type ValidationResult = {
   ifcClassificationReference: IfcClassificationReference;
@@ -69,11 +69,6 @@ function findMatchedClass(
   );
 }
 
-function handleError(message: string, ifcClassificationReference: IfcClassificationReference): ValidationResult {
-  console.error(message);
-  return { ifcClassificationReference, validationState: 'invalid', message };
-}
-
 export async function patchIfcClassificationReference(
   ifcClassificationReference: IfcClassificationReference,
   queryClient: QueryClient,
@@ -83,29 +78,26 @@ export async function patchIfcClassificationReference(
     return { ifcClassificationReference, validationState: 'valid', message: 'Location is already set' };
   }
 
-  const location = ifcClassificationReference.referencedSource?.location ?? ifcClassificationReference.location;
+  const location = ifcClassificationReference.referencedSource?.location;
   if (!location) {
-    return handleError(
-      'Cannot patch IfcClassificationReference: missing referencedSource or its location',
-      ifcClassificationReference,
-    );
+    // No dictionary to look up against — pass through unchanged.
+    return { ifcClassificationReference, validationState: 'valid', message: null };
   }
 
   const classes = await ensureDictionaryClasses(queryClient, location, language);
   if (!classes) {
-    return handleError('Failed to fetch classes for the referencedSource location', ifcClassificationReference);
+    // ensureDictionaryClasses already logs the network error — pass through unchanged.
+    return { ifcClassificationReference, validationState: 'valid', message: null };
   }
 
   const matchedClass = findMatchedClass(ifcClassificationReference, classes);
   if (!matchedClass) {
-    return handleError(
-      'Failed to find a match for the IfcClassificationReference code or name in the classes',
-      ifcClassificationReference,
-    );
+    // No matching class found — pass through unchanged rather than dropping the reference.
+    return { ifcClassificationReference, validationState: 'valid', message: null };
   }
 
   if (!matchedClass.uri) {
-    return handleError('Failed to find a URI for the matched class', ifcClassificationReference);
+    return { ifcClassificationReference, validationState: 'valid', message: null };
   }
 
   const { uri, code, name } = matchedClass;
@@ -118,12 +110,12 @@ export async function patchIfcClassificationReference(
   };
 
   if (!newRef.referencedSource?.location) {
-    return handleError('referencedSource or its location is missing', newRef);
+    return { ifcClassificationReference: newRef, validationState: 'valid', message: null };
   }
 
   const bsddDictionary = await ensureDictionary(queryClient, newRef.referencedSource.location);
   if (!bsddDictionary) {
-    return handleError(`Failed to find a matching dictionary for: ${newRef.location}`, newRef);
+    return { ifcClassificationReference: newRef, validationState: 'valid', message: null };
   }
 
   newRef.referencedSource = convertBsddDictionaryToIfcClassification(bsddDictionary);
@@ -136,21 +128,15 @@ async function processAssociations(
   queryClient: QueryClient,
   language: string,
 ): Promise<Association[]> {
-  const processedAssociations = await Promise.all(
+  return Promise.all(
     associations.map(async (association) => {
       if (association.type === 'IfcClassificationReference') {
-        const { ifcClassificationReference, validationState } = await patchIfcClassificationReference(
-          association,
-          queryClient,
-          language,
-        );
-        if (validationState === 'invalid') return null;
+        const { ifcClassificationReference } = await patchIfcClassificationReference(association, queryClient, language);
         return ifcClassificationReference;
       }
       return association;
     }),
   );
-  return processedAssociations.filter((a) => a !== null) as Association[];
 }
 
 function ifcEntityAsType(ifcEntity: string) {


### PR DESCRIPTION
IfcClassificationReference objects without a resolvable bSDD location were silently dropped from entity associations and logged as errors. This caused console spam for mock data (and real-world data) where classification references point to non-bSDD or unconfigured dictionaries.

Now patchIfcClassificationReference passes unresolvable references through unchanged. Only genuine network failures in the dictionary/class fetchers still log via console.error. Removes the 'invalid' ValidationState variant and simplifies processAssociations accordingly.