### PR TITLE
fix: restore unauth rate-limit headroom and handle CORS-blocked 429s

### DIFF
--- a/shared/bsdd-api/BsddApiClient.test.ts
+++ b/shared/bsdd-api/BsddApiClient.test.ts
@@ -45,17 +45,27 @@ describe('BsddApiClient', () => {
   });
 
   describe('TypeError backoff (CORS-blocked 429)', () => {
-    it('doubles adaptiveMinDelay and sets a 2s cooldown when fetch() throws TypeError', async () => {
+    it('increments rateLimitHits and sets a 2s cooldown when fetch() throws TypeError', async () => {
       mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
       const client = new BsddApiClient({ minDelay: 0 });
 
       await expect(client.fetch('https://example.com')).rejects.toBeInstanceOf(TypeError);
 
       const stats = client.getRateLimitStats();
-      // adaptiveMinDelay should have doubled from the floor (0 → max(0*2, 0*2)=0 but minDelay*2=0).
-      // Use a non-zero floor to verify the doubling:
       expect(stats.rateLimitHits).toBe(1);
       expect(stats.cooldownRemainingMs).toBeGreaterThan(1_500);
+    });
+
+    it('does not apply backoff for non-TypeError exceptions (e.g. AbortError)', async () => {
+      const abortError = new DOMException('Aborted', 'AbortError');
+      mockFetch.mockRejectedValueOnce(abortError);
+      const client = new BsddApiClient({ minDelay: 0 });
+
+      await expect(client.fetch('https://example.com')).rejects.toThrow('Aborted');
+
+      const stats = client.getRateLimitStats();
+      expect(stats.rateLimitHits).toBe(0);
+      expect(stats.cooldownRemainingMs).toBe(0);
     });
 
     it('doubles adaptiveMinDelay from a non-zero floor on TypeError', async () => {

--- a/shared/bsdd-api/BsddApiClient.test.ts
+++ b/shared/bsdd-api/BsddApiClient.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BsddApiClient, BsddRateLimitError } from './BsddApiClient';
+
+const mockFetch = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeOk(): Response {
+  return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
+
+function make429WithCors(): Response {
+  return new Response('rate limited', {
+    status: 429,
+    headers: { 'Access-Control-Allow-Origin': '*', 'Retry-After': '2' },
+  });
+}
+
+describe('BsddApiClient', () => {
+  describe('default unauthenticated floor', () => {
+    it('defaults to 400 ms to maintain headroom under the 10 calls/2s anonymous ceiling', () => {
+      const client = new BsddApiClient();
+      // Access via getRateLimitStats — adaptiveMinDelay starts at the floor.
+      expect(client.getRateLimitStats().adaptiveMinDelayMs).toBe(400);
+    });
+
+    it('drops to 100 ms after setAuthenticated(true)', () => {
+      const client = new BsddApiClient();
+      client.setAuthenticated(true);
+      expect(client.getRateLimitStats().adaptiveMinDelayMs).toBe(100);
+    });
+
+    it('returns to 400 ms after setAuthenticated(false)', () => {
+      const client = new BsddApiClient();
+      client.setAuthenticated(true);
+      client.setAuthenticated(false);
+      expect(client.getRateLimitStats().adaptiveMinDelayMs).toBe(400);
+    });
+  });
+
+  describe('TypeError backoff (CORS-blocked 429)', () => {
+    it('doubles adaptiveMinDelay and sets a 2s cooldown when fetch() throws TypeError', async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+      const client = new BsddApiClient({ minDelay: 0 });
+
+      await expect(client.fetch('https://example.com')).rejects.toBeInstanceOf(TypeError);
+
+      const stats = client.getRateLimitStats();
+      // adaptiveMinDelay should have doubled from the floor (0 → max(0*2, 0*2)=0 but minDelay*2=0).
+      // Use a non-zero floor to verify the doubling:
+      expect(stats.rateLimitHits).toBe(1);
+      expect(stats.cooldownRemainingMs).toBeGreaterThan(1_500);
+    });
+
+    it('doubles adaptiveMinDelay from a non-zero floor on TypeError', async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+      const client = new BsddApiClient({ minDelay: 100 });
+
+      await expect(client.fetch('https://example.com')).rejects.toBeInstanceOf(TypeError);
+
+      const stats = client.getRateLimitStats();
+      // adaptiveMinDelay starts at 100, doubles to 200 on TypeError.
+      expect(stats.adaptiveMinDelayMs).toBe(200);
+      expect(stats.rateLimitHits).toBe(1);
+    });
+
+    it('does not suppress the TypeError — it propagates to the caller', async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+      const client = new BsddApiClient({ minDelay: 0 });
+
+      await expect(client.fetch('https://example.com')).rejects.toThrow(TypeError);
+    });
+
+    it('recovers after a TypeError: next successful fetch decays adaptiveMinDelay', async () => {
+      mockFetch
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+        .mockResolvedValueOnce(makeOk());
+
+      const client = new BsddApiClient({ minDelay: 0 });
+      await expect(client.fetch('https://example.com')).rejects.toBeInstanceOf(TypeError);
+
+      vi.useFakeTimers();
+      // Advance past the 2s cooldown so the next request is not blocked.
+      vi.advanceTimersByTime(3_000);
+
+      const response = await client.fetch('https://example.com');
+      expect(response.status).toBe(200);
+      vi.useRealTimers();
+    });
+  });
+
+  describe('429 with CORS headers (visible to browser)', () => {
+    it('throws BsddRateLimitError and doubles adaptiveMinDelay', async () => {
+      mockFetch.mockResolvedValueOnce(make429WithCors());
+      const client = new BsddApiClient({ minDelay: 200 });
+
+      await expect(client.fetch('https://example.com')).rejects.toBeInstanceOf(BsddRateLimitError);
+
+      const stats = client.getRateLimitStats();
+      expect(stats.rateLimitHits).toBe(1);
+      expect(stats.adaptiveMinDelayMs).toBe(400);
+    });
+  });
+
+  describe('setAuthenticated', () => {
+    it('is a no-op when the tier does not change', () => {
+      const client = new BsddApiClient({ minDelay: 400 });
+      const before = client.getRateLimitStats().adaptiveMinDelayMs;
+      client.setAuthenticated(false);
+      expect(client.getRateLimitStats().adaptiveMinDelayMs).toBe(before);
+    });
+  });
+});

--- a/shared/bsdd-api/BsddApiClient.ts
+++ b/shared/bsdd-api/BsddApiClient.ts
@@ -3,7 +3,12 @@
 
 interface BsddApiClientConfig {
   baseURL?: string;
-  /** Floor between requests when unauthenticated. Defaults to 200 ms (10 calls/2s per IP). */
+  /**
+   * Floor between requests when unauthenticated. Defaults to 400 ms (~2.5 calls/s).
+   * bSDD's anonymous ceiling is 10 calls/2s per IP. The floor is the minimum *between*
+   * requests, not the call duration; fast responses (sub-200 ms) would push actual
+   * throughput above the ceiling at 200 ms, so 400 ms gives 4× headroom.
+   */
   minDelay?: number;
   /** Floor between requests when authenticated. Defaults to 100 ms (30 calls/2s per user, with margin). */
   authenticatedMinDelay?: number;
@@ -55,7 +60,7 @@ export class BsddApiClient {
 
   constructor(config: BsddApiClientConfig = {}) {
     this._baseURL = config.baseURL ?? 'https://api.bsdd.buildingsmart.org';
-    this.unauthenticatedMinDelay = config.minDelay ?? 200;
+    this.unauthenticatedMinDelay = config.minDelay ?? 400;
     this.authenticatedMinDelay = config.authenticatedMinDelay ?? 100;
     this.minDelay = this.unauthenticatedMinDelay;
     this.appName = config.appName ?? 'bsdd-filter-ui';
@@ -118,7 +123,24 @@ export class BsddApiClient {
       this.stats.totalRequests++;
       await this.waitMinDelay();
       const { url, init } = buildRequest();
-      const response = await fetch(url, init);
+
+      let response: Response;
+      try {
+        response = await fetch(url, init);
+      } catch (err) {
+        // fetch() throws TypeError when the browser blocks a response for CORS violations.
+        // bSDD's CDN omits Access-Control-Allow-Origin on 429 responses, so a CORS block
+        // here is likely a masked rate limit. Apply the same doubling backoff as a real 429
+        // so the queue slows down even though we cannot confirm the HTTP status.
+        this.stats.rateLimitHits++;
+        this.adaptiveMinDelay = Math.min(
+          this.adaptiveMaxDelay,
+          Math.max(this.adaptiveMinDelay * 2, this.minDelay * 2),
+        );
+        const until = Date.now() + 2_000;
+        if (until > this.cooldownUntil) this.cooldownUntil = until;
+        throw err;
+      }
 
       if (response.status === 429 || response.status === 503) {
         this.stats.rateLimitHits++;

--- a/shared/bsdd-api/BsddApiClient.ts
+++ b/shared/bsdd-api/BsddApiClient.ts
@@ -7,7 +7,7 @@ interface BsddApiClientConfig {
    * Floor between requests when unauthenticated. Defaults to 400 ms (~2.5 calls/s).
    * bSDD's anonymous ceiling is 10 calls/2s per IP. The floor is the minimum *between*
    * requests, not the call duration; fast responses (sub-200 ms) would push actual
-   * throughput above the ceiling at 200 ms, so 400 ms gives 4× headroom.
+   * throughput above the ceiling at 200 ms, so 400 ms gives ~2× headroom.
    */
   minDelay?: number;
   /** Floor between requests when authenticated. Defaults to 100 ms (30 calls/2s per user, with margin). */
@@ -128,17 +128,21 @@ export class BsddApiClient {
       try {
         response = await fetch(url, init);
       } catch (err) {
+        // Only TypeError indicates a network/CORS block — AbortError and others should
+        // propagate without being counted as rate-limit hits.
         // fetch() throws TypeError when the browser blocks a response for CORS violations.
         // bSDD's CDN omits Access-Control-Allow-Origin on 429 responses, so a CORS block
         // here is likely a masked rate limit. Apply the same doubling backoff as a real 429
         // so the queue slows down even though we cannot confirm the HTTP status.
-        this.stats.rateLimitHits++;
-        this.adaptiveMinDelay = Math.min(
-          this.adaptiveMaxDelay,
-          Math.max(this.adaptiveMinDelay * 2, this.minDelay * 2),
-        );
-        const until = Date.now() + 2_000;
-        if (until > this.cooldownUntil) this.cooldownUntil = until;
+        if (err instanceof TypeError) {
+          this.stats.rateLimitHits++;
+          this.adaptiveMinDelay = Math.min(
+            this.adaptiveMaxDelay,
+            Math.max(this.adaptiveMinDelay * 2, this.minDelay * 2),
+          );
+          const until = Date.now() + 2_000;
+          if (until > this.cooldownUntil) this.cooldownUntil = until;
+        }
         throw err;
       }
 

--- a/src/lib/api/bsddApiInstance.test.ts
+++ b/src/lib/api/bsddApiInstance.test.ts
@@ -1,7 +1,7 @@
 // Purpose: Verify that the hey-api request interceptor injects Authorization when a token is set
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { _authInterceptor, setBsddAccessToken } from './bsddApiInstance';
+import { _authInterceptor, _errorInterceptor, setBsddAccessToken } from './bsddApiInstance';
 
 afterEach(() => {
   setBsddAccessToken(undefined);
@@ -27,5 +27,36 @@ describe('bSDD auth interceptor', () => {
     setBsddAccessToken(undefined);
     const reqWithout = _authInterceptor(new Request('https://api.bsdd.buildingsmart.org/api/Dictionary/v1'));
     expect(reqWithout.headers.get('Authorization')).toBeNull();
+  });
+});
+
+describe('bSDD error interceptor', () => {
+  it('wraps 4xx bodies in Error with .status so isClientError can identify them as non-retryable', () => {
+    const body = { message: 'Not Found' };
+    const response = new Response(null, { status: 404 });
+    const result = _errorInterceptor(body, response);
+    expect(result).toBeInstanceOf(Error);
+    expect((result as { status: number }).status).toBe(404);
+  });
+
+  it('wraps 400 bad request the same way', () => {
+    const response = new Response(null, { status: 400 });
+    const result = _errorInterceptor('Bad Request', response);
+    expect(result).toBeInstanceOf(Error);
+    expect((result as { status: number }).status).toBe(400);
+  });
+
+  it('passes 5xx bodies through unchanged — server errors are retriable', () => {
+    const body = 'Internal Server Error';
+    const response = new Response(null, { status: 500 });
+    expect(_errorInterceptor(body, response)).toBe(body);
+  });
+
+  it('passes 429 body through unchanged — 429 is handled by the transport, not this interceptor', () => {
+    // Defensive: if a 429 somehow reaches this interceptor it must NOT be converted to a
+    // permanent client error, or TanStack Query would skip the rate-limit retry logic.
+    const body = 'Too Many Requests';
+    const response429 = new Response(null, { status: 429 });
+    expect(_errorInterceptor(body, response429)).toBe(body);
   });
 });

--- a/src/lib/api/bsddApiInstance.test.ts
+++ b/src/lib/api/bsddApiInstance.test.ts
@@ -52,6 +52,11 @@ describe('bSDD error interceptor', () => {
     expect(_errorInterceptor(body, response)).toBe(body);
   });
 
+  it('passes body through unchanged when response is undefined (fetch exception path)', () => {
+    const body = new TypeError('Failed to fetch');
+    expect(_errorInterceptor(body, undefined)).toBe(body);
+  });
+
   it('passes 429 body through unchanged — 429 is handled by the transport, not this interceptor', () => {
     // Defensive: if a 429 somehow reaches this interceptor it must NOT be converted to a
     // permanent client error, or TanStack Query would skip the rate-limit retry logic.

--- a/src/lib/api/bsddApiInstance.ts
+++ b/src/lib/api/bsddApiInstance.ts
@@ -44,7 +44,10 @@ client.interceptors.request.use(_authInterceptor);
 // This interceptor wraps them so the check works. 429 and 503 are intercepted upstream
 // by the transport and never reach here.
 // Exported for unit testing only.
-export const _errorInterceptor = (body: unknown, response: Response): unknown => {
+export const _errorInterceptor = (body: unknown, response: Response | undefined): unknown => {
+  // hey-api also calls error interceptors for fetch exceptions (network/AbortError),
+  // where `response` is undefined. Pass those through unchanged.
+  if (!response) return body;
   // 429 and 503 are handled by the transport (BsddRateLimitError) before hey-api sees them;
   // they never reach this interceptor in normal operation. Exclude them defensively so that
   // if they ever did arrive here they would not be misidentified as permanent client errors.

--- a/src/lib/api/bsddApiInstance.ts
+++ b/src/lib/api/bsddApiInstance.ts
@@ -41,8 +41,8 @@ client.interceptors.request.use(_authInterceptor);
 // hey-api with throwOnError:true throws the parsed response body (a plain object/string),
 // not an Error instance. isClientError() in queryClient checks for Error-with-.status,
 // so plain-object 4xx throws would bypass it and get retried unnecessarily.
-// This interceptor wraps them so the check works. 429 and 503 are intercepted upstream
-// by the transport and never reach here.
+// This interceptor wraps them so the check works. Raw 429/503 responses are converted upstream
+// into BsddRateLimitError (a fetch exception), so they arrive here with `response` undefined.
 // Exported for unit testing only.
 export const _errorInterceptor = (body: unknown, response: Response | undefined): unknown => {
   // hey-api also calls error interceptors for fetch exceptions (network/AbortError),

--- a/src/lib/api/bsddApiInstance.ts
+++ b/src/lib/api/bsddApiInstance.ts
@@ -37,3 +37,21 @@ export const _authInterceptor = (request: Request): Request => {
 };
 
 client.interceptors.request.use(_authInterceptor);
+
+// hey-api with throwOnError:true throws the parsed response body (a plain object/string),
+// not an Error instance. isClientError() in queryClient checks for Error-with-.status,
+// so plain-object 4xx throws would bypass it and get retried unnecessarily.
+// This interceptor wraps them so the check works. 429 and 503 are intercepted upstream
+// by the transport and never reach here.
+// Exported for unit testing only.
+export const _errorInterceptor = (body: unknown, response: Response): unknown => {
+  // 429 and 503 are handled by the transport (BsddRateLimitError) before hey-api sees them;
+  // they never reach this interceptor in normal operation. Exclude them defensively so that
+  // if they ever did arrive here they would not be misidentified as permanent client errors.
+  if (response.status >= 400 && response.status < 500 && response.status !== 429) {
+    return Object.assign(new Error(`bSDD API error ${response.status}`), { status: response.status });
+  }
+  return body;
+};
+
+client.interceptors.error.use(_errorInterceptor);

--- a/src/lib/api/queryClient.test.ts
+++ b/src/lib/api/queryClient.test.ts
@@ -32,10 +32,13 @@ describe('createBsddQueryClient', () => {
     expect(retry(2, generic)).toBe(false);
   });
 
-  it('retryDelay honours BsddRateLimitError.retryAfterMs but falls back to a 1s default', () => {
+  it('retryDelay honours BsddRateLimitError.retryAfterMs, uses 3s for TypeError, falls back to 1s', () => {
     const opts = createBsddQueryClient().getDefaultOptions().queries!;
     const retryDelay = opts.retryDelay as (n: number, e: unknown) => number;
     expect(retryDelay(0, new BsddRateLimitError(2500, 429))).toBe(2500);
+    // TypeError covers CORS-blocked 429s (bSDD omits CORS headers on rate-limited responses).
+    // A longer delay lets the transport cooldown take effect before the retry is queued.
+    expect(retryDelay(0, new TypeError('Failed to fetch'))).toBe(3000);
     expect(retryDelay(0, new Error('other'))).toBe(1000);
   });
 });

--- a/src/lib/api/queryClient.ts
+++ b/src/lib/api/queryClient.ts
@@ -19,11 +19,18 @@ export function createBsddQueryClient() {
         gcTime: 1000 * 60 * 60 * 24, // 24 hours — must be ≥ persister maxAge
         refetchOnWindowFocus: false,
         // 4xx errors are permanent — never retry. Respect Retry-After for 429/503.
+        // TypeErrors (including CORS-blocked 429s — bSDD omits CORS headers on rate-limit
+        // responses) get a longer initial delay so the transport cooldown has time to take
+        // effect before the retry lands in the queue.
         retry: (failureCount: number, error: unknown) => {
           if (isClientError(error)) return false;
           return error instanceof BsddRateLimitError ? failureCount < 6 : failureCount < 2;
         },
-        retryDelay: (_: number, error: unknown) => (error instanceof BsddRateLimitError ? error.retryAfterMs : 1_000),
+        retryDelay: (_: number, error: unknown) => {
+          if (error instanceof BsddRateLimitError) return error.retryAfterMs;
+          if (error instanceof TypeError) return 3_000;
+          return 1_000;
+        },
       },
     },
   });


### PR DESCRIPTION
Four-part fix for the regression introduced in 4a982c0 where unauthenticated requests fail with net::ERR_FAILED + CORS errors in the browser console:

1. Raise unauthenticatedMinDelay 200 → 400 ms (BsddApiClient.ts). 200 ms put throughput at 5 req/s — exactly the 10 calls/2s anonymous ceiling with zero burst margin. Sub-200 ms responses (CDN hits) pushed actual throughput over it. 400 ms gives 2× headroom (~2.5 req/s).

2. Catch TypeError in scheduledFetch and apply the same doubling backoff as a visible 429 (BsddApiClient.ts). bSDD's CDN omits Access-Control-Allow-Origin on rate-limited responses, so fetch() throws TypeError instead of resolving with Response(429). The existing 429 handler was unreachable in that case, leaving cooldownUntil and adaptiveMinDelay unchanged and letting TanStack Query's generic retry logic compound the burst.

3. Increase TypeError retryDelay 1 s → 3 s (queryClient.ts) so the transport cooldown has time to take effect before the retry reaches the queue.

4. Add hey-api error interceptor in bsddApiInstance.ts that wraps 4xx response bodies in Error objects carrying the HTTP status. hey-api with throwOnError:true throws the parsed body (plain object/string), not a Response or Error, so isClientError() could not identify 400/404 responses and was retrying them unnecessarily. 429 and 503 are handled upstream by the transport and are explicitly excluded from wrapping so they are never misidentified as permanent failures.

Adds BsddApiClient.test.ts (9 tests) and extends bsddApiInstance.test.ts (4 new tests) covering floor defaults, auth-tier switching, TypeError backoff, visible-429 handling, and the error-interceptor contract.