### PR TITLE
fix: retry CORS-masked 429s on the rate-limit path with escalating waits

### DIFF
--- a/shared/bsdd-api/BsddApiClient.test.ts
+++ b/shared/bsdd-api/BsddApiClient.test.ts
@@ -45,11 +45,15 @@ describe('BsddApiClient', () => {
   });
 
   describe('TypeError backoff (CORS-blocked 429)', () => {
-    it('increments rateLimitHits and sets a 2s cooldown when fetch() throws TypeError', async () => {
+    it('wraps the TypeError in a masked BsddRateLimitError and sets a 2s cooldown', async () => {
       mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
       const client = new BsddApiClient({ minDelay: 0 });
 
-      await expect(client.fetch('https://example.com')).rejects.toBeInstanceOf(TypeError);
+      await expect(client.fetch('https://example.com')).rejects.toMatchObject({
+        name: 'BsddRateLimitError',
+        masked: true,
+        retryAfterMs: 2_100,
+      });
 
       const stats = client.getRateLimitStats();
       expect(stats.rateLimitHits).toBe(1);
@@ -72,7 +76,7 @@ describe('BsddApiClient', () => {
       mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
       const client = new BsddApiClient({ minDelay: 100 });
 
-      await expect(client.fetch('https://example.com')).rejects.toBeInstanceOf(TypeError);
+      await expect(client.fetch('https://example.com')).rejects.toBeInstanceOf(BsddRateLimitError);
 
       const stats = client.getRateLimitStats();
       // adaptiveMinDelay starts at 100, doubles to 200 on TypeError.
@@ -80,27 +84,42 @@ describe('BsddApiClient', () => {
       expect(stats.rateLimitHits).toBe(1);
     });
 
-    it('does not suppress the TypeError — it propagates to the caller', async () => {
-      mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    it('escalates the masked cooldown on consecutive CORS-blocked failures', async () => {
+      vi.useFakeTimers();
+      mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
       const client = new BsddApiClient({ minDelay: 0 });
 
-      await expect(client.fetch('https://example.com')).rejects.toThrow(TypeError);
+      await expect(client.fetch('https://example.com')).rejects.toMatchObject({ retryAfterMs: 2_100 });
+
+      const second = client.fetch('https://example.com');
+      second.catch(() => undefined);
+      await vi.advanceTimersByTimeAsync(2_100);
+      await expect(second).rejects.toMatchObject({ retryAfterMs: 4_100 });
+
+      const third = client.fetch('https://example.com');
+      third.catch(() => undefined);
+      await vi.advanceTimersByTimeAsync(4_100);
+      await expect(third).rejects.toMatchObject({ retryAfterMs: 8_100 });
+      vi.useRealTimers();
     });
 
-    it('recovers after a TypeError: next successful fetch decays adaptiveMinDelay', async () => {
+    it('recovers after a TypeError: next response resets the masked cooldown', async () => {
       mockFetch
         .mockRejectedValueOnce(new TypeError('Failed to fetch'))
-        .mockResolvedValueOnce(makeOk());
+        .mockResolvedValueOnce(makeOk())
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'));
 
       const client = new BsddApiClient({ minDelay: 0 });
-      await expect(client.fetch('https://example.com')).rejects.toBeInstanceOf(TypeError);
+      await expect(client.fetch('https://example.com')).rejects.toBeInstanceOf(BsddRateLimitError);
 
       vi.useFakeTimers();
-      // Advance past the 2s cooldown so the next request is not blocked.
-      vi.advanceTimersByTime(3_000);
 
-      const response = await client.fetch('https://example.com');
-      expect(response.status).toBe(200);
+      const ok = client.fetch('https://example.com');
+      await vi.advanceTimersByTimeAsync(2_100);
+      expect((await ok).status).toBe(200);
+
+      // The escalation restarts at 2s instead of continuing to 4s.
+      await expect(client.fetch('https://example.com')).rejects.toMatchObject({ retryAfterMs: 2_100 });
       vi.useRealTimers();
     });
   });

--- a/shared/bsdd-api/BsddApiClient.ts
+++ b/shared/bsdd-api/BsddApiClient.ts
@@ -16,13 +16,26 @@ interface BsddApiClientConfig {
   appVersion?: string;
 }
 
-/** Thrown when bSDD responds 429/503. TanStack Query retryDelay reads retryAfterMs. */
+/**
+ * Thrown when bSDD responds 429/503. TanStack Query retryDelay reads retryAfterMs.
+ * `masked: true` means the browser blocked the response for CORS (bSDD omits
+ * Access-Control-Allow-Origin on rate-limited responses), so the status is presumed
+ * and retryAfterMs is a synthetic escalating estimate rather than a server value.
+ * Deliberately carries no `status` property: queryClient's isClientError treats
+ * Error-with-status as permanent, which would disable retries.
+ */
 export class BsddRateLimitError extends Error {
   readonly retryAfterMs: number;
-  constructor(retryAfterMs: number, status: number) {
-    super(`bSDD rate limit (${status}): retry after ${retryAfterMs}ms`);
+  readonly masked: boolean;
+  constructor(retryAfterMs: number, status: number, masked = false) {
+    super(
+      masked
+        ? `bSDD rate limit (CORS-masked, presumed ${status}): retry after ${retryAfterMs}ms`
+        : `bSDD rate limit (${status}): retry after ${retryAfterMs}ms`,
+    );
     this.name = 'BsddRateLimitError';
     this.retryAfterMs = retryAfterMs;
+    this.masked = masked;
   }
 }
 
@@ -54,6 +67,12 @@ export class BsddApiClient {
   // Adaptive min-delay: doubles on 429, decays 0.95x per success.
   private adaptiveMinDelay = 0;
   private readonly adaptiveMaxDelay = 5_000;
+
+  // Escalating cooldown for CORS-masked 429s, where Retry-After is unreadable:
+  // 2s on first hit, doubling to 30s. Resets once any real response arrives.
+  private maskedCooldownMs = 1_000;
+  private readonly maskedCooldownBaseMs = 1_000;
+  private readonly maskedCooldownMaxMs = 30_000;
 
   // Observability.
   private stats = { totalRequests: 0, rateLimitHits: 0 };
@@ -132,19 +151,24 @@ export class BsddApiClient {
         // propagate without being counted as rate-limit hits.
         // fetch() throws TypeError when the browser blocks a response for CORS violations.
         // bSDD's CDN omits Access-Control-Allow-Origin on 429 responses, so a CORS block
-        // here is likely a masked rate limit. Apply the same doubling backoff as a real 429
-        // so the queue slows down even though we cannot confirm the HTTP status.
+        // here is likely a masked rate limit. Convert it to a masked BsddRateLimitError so
+        // callers retry it on the rate-limit path (escalating waits) instead of treating it
+        // as a generic network failure that exhausts retries while the penalty still runs.
         if (err instanceof TypeError) {
           this.stats.rateLimitHits++;
           this.adaptiveMinDelay = Math.min(
             this.adaptiveMaxDelay,
             Math.max(this.adaptiveMinDelay * 2, this.minDelay * 2),
           );
-          const until = Date.now() + 2_000;
+          this.maskedCooldownMs = Math.min(this.maskedCooldownMaxMs, this.maskedCooldownMs * 2);
+          const until = Date.now() + this.maskedCooldownMs;
           if (until > this.cooldownUntil) this.cooldownUntil = until;
+          throw new BsddRateLimitError(this.maskedCooldownMs + 100, 429, true);
         }
         throw err;
       }
+      // A real response arrived, so CORS is not being masked any more.
+      this.maskedCooldownMs = this.maskedCooldownBaseMs;
 
       if (response.status === 429 || response.status === 503) {
         this.stats.rateLimitHits++;

--- a/shared/bsdd-api/BsddApiClient.ts
+++ b/shared/bsdd-api/BsddApiClient.ts
@@ -161,7 +161,7 @@ export class BsddApiClient {
             Math.max(this.adaptiveMinDelay * 2, this.minDelay * 2),
           );
           this.maskedCooldownMs = Math.min(this.maskedCooldownMaxMs, this.maskedCooldownMs * 2);
-          const waitMs = this.maskedCooldownMs + 100;
+          const waitMs = Math.min(this.maskedCooldownMaxMs, this.maskedCooldownMs + 100);
           const until = Date.now() + waitMs;
           if (until > this.cooldownUntil) this.cooldownUntil = until;
           throw new BsddRateLimitError(waitMs, 429, true);

--- a/shared/bsdd-api/BsddApiClient.ts
+++ b/shared/bsdd-api/BsddApiClient.ts
@@ -161,9 +161,10 @@ export class BsddApiClient {
             Math.max(this.adaptiveMinDelay * 2, this.minDelay * 2),
           );
           this.maskedCooldownMs = Math.min(this.maskedCooldownMaxMs, this.maskedCooldownMs * 2);
-          const until = Date.now() + this.maskedCooldownMs;
+          const waitMs = this.maskedCooldownMs + 100;
+          const until = Date.now() + waitMs;
           if (until > this.cooldownUntil) this.cooldownUntil = until;
-          throw new BsddRateLimitError(this.maskedCooldownMs + 100, 429, true);
+          throw new BsddRateLimitError(waitMs, 429, true);
         }
         throw err;
       }

--- a/src/lib/api/queryClient.test.ts
+++ b/src/lib/api/queryClient.test.ts
@@ -26,6 +26,11 @@ describe('createBsddQueryClient', () => {
     expect(retry(5, rateLimit)).toBe(true);
     expect(retry(6, rateLimit)).toBe(false);
 
+    // CORS-masked 429s from the transport get the same full retry budget.
+    const masked = new BsddRateLimitError(2_100, 429, true);
+    expect(retry(5, masked)).toBe(true);
+    expect(retry(6, masked)).toBe(false);
+
     const generic = new Error('boom');
     expect(retry(0, generic)).toBe(true);
     expect(retry(1, generic)).toBe(true);
@@ -36,8 +41,9 @@ describe('createBsddQueryClient', () => {
     const opts = createBsddQueryClient().getDefaultOptions().queries!;
     const retryDelay = opts.retryDelay as (n: number, e: unknown) => number;
     expect(retryDelay(0, new BsddRateLimitError(2500, 429))).toBe(2500);
-    // TypeError covers CORS-blocked 429s (bSDD omits CORS headers on rate-limited responses).
-    // A longer delay lets the transport cooldown take effect before the retry is queued.
+    // Masked (CORS-blocked) 429s carry a synthetic escalating retryAfterMs from the transport.
+    expect(retryDelay(0, new BsddRateLimitError(2100, 429, true))).toBe(2100);
+    // The TypeError branch only covers fetches that bypass the transport.
     expect(retryDelay(0, new TypeError('Failed to fetch'))).toBe(3000);
     expect(retryDelay(0, new Error('other'))).toBe(1000);
   });

--- a/src/lib/api/queryClient.ts
+++ b/src/lib/api/queryClient.ts
@@ -19,9 +19,10 @@ export function createBsddQueryClient() {
         gcTime: 1000 * 60 * 60 * 24, // 24 hours — must be ≥ persister maxAge
         refetchOnWindowFocus: false,
         // 4xx errors are permanent — never retry. Respect Retry-After for 429/503.
-        // TypeErrors (including CORS-blocked 429s — bSDD omits CORS headers on rate-limit
-        // responses) get a longer initial delay so the transport cooldown has time to take
-        // effect before the retry lands in the queue.
+        // CORS-blocked 429s (bSDD omits CORS headers on rate-limit responses) arrive as
+        // masked BsddRateLimitError from the transport, with a synthetic escalating
+        // retryAfterMs — they get the full 6-retry budget. The TypeError branch below only
+        // covers fetches that bypass the transport.
         retry: (failureCount: number, error: unknown) => {
           if (isClientError(error)) return false;
           return error instanceof BsddRateLimitError ? failureCount < 6 : failureCount < 2;


### PR DESCRIPTION
bSDD omits Access-Control-Allow-Origin on 429 responses, so the browser masks them as fetch TypeErrors. Those were retried as generic network errors (2 retries, fixed 3s) — usually still inside the server's penalty window — so queries failed permanently and classification selects stuck on loading/error while authenticated sessions worked fine.

The transport now converts the TypeError into BsddRateLimitError with masked:true and a synthetic escalating retryAfterMs (2s doubling to a 30s cap, reset once any real response arrives). That routes masked 429s onto the existing rate-limit retry path: 6 retries honouring the wait (~90s total budget), with the transport's global cooldown holding the FIFO queue back between attempts.

BsddRateLimitError deliberately carries no `status` property — queryClient's isClientError treats Error-with-status as a permanent 4xx and would disable retries.

Verified against the live API: 50 GETs at the 400ms floor and 25 preflight OPTIONS+GET pairs from a clean IP produce zero 429s, so the floor itself is sound; anonymous 429s come from the shared account-wide pool (1500 calls/60s) and must be ridden out, not avoided.