### PR TITLE
feat: Hybrid slicer class search: ranked results, full load for small dictionaries

### DIFF
--- a/src/lib/BsddSearch/Search.tsx
+++ b/src/lib/BsddSearch/Search.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useSearchInDictionary } from '../api/hooks/useSearchInDictionary';
+import { type SearchMatchedOn, rankClassSearchResults } from '../common/tools/rankClassSearchResults';
 import { useSettingsStore } from '../stores/settingsStore';
 
 export const SEARCH_INPUT_ID = 'bsdd-class-search';
@@ -12,7 +13,7 @@ interface Option {
   label: string;
   value: string;
   code?: string;
-  matchedOn?: 'synonym' | 'description';
+  matchedOn?: SearchMatchedOn;
 }
 
 interface Props {
@@ -46,38 +47,18 @@ function Search({ value, onCommit, seedText, resolving }: Props) {
   const query = combobox.dropdownOpened ? queryText.trim() : '';
   const { data: searchResult, isFetching } = useSearchInDictionary(dictionaryUri, query);
 
-  // The bSDD search matches names, codes, synonyms and descriptions but returns
-  // hits alphabetically. Rank name matches first so the highlighted first option
-  // (committed on Enter) is the best match, and tag the indirect hits with why
-  // they matched.
-  const options = useMemo<Option[]>(() => {
-    const lcQuery = query.toLowerCase();
-    const ranked = (searchResult?.dictionary?.classes ?? [])
-      .filter((c) => c.uri && c.name)
-      .map((c) => {
-        const name = (c.name as string).toLowerCase();
-        const code = c.referenceCode?.toLowerCase() ?? '';
-        let tier: number;
-        let matchedOn: Option['matchedOn'];
-        if (name === lcQuery) tier = 0;
-        else if (name.startsWith(lcQuery)) tier = 1;
-        else if (name.includes(lcQuery)) tier = 2;
-        else if (code.includes(lcQuery)) tier = 3;
-        else if (c.synonyms?.some((s) => s.toLowerCase().includes(lcQuery))) {
-          tier = 4;
-          matchedOn = 'synonym';
-        } else {
-          tier = 5;
-          if (c.definition?.toLowerCase().includes(lcQuery)) matchedOn = 'description';
-        }
-        return {
-          tier,
-          option: { value: c.uri as string, label: c.name as string, code: c.referenceCode ?? undefined, matchedOn },
-        };
-      });
-    ranked.sort((a, b) => a.tier - b.tier || a.option.label.localeCompare(b.option.label));
-    return ranked.map((r) => r.option);
-  }, [searchResult, query]);
+  // Rank name matches first so the highlighted first option (committed on
+  // Enter) is the best match, and tag the indirect hits with why they matched.
+  const options = useMemo<Option[]>(
+    () =>
+      rankClassSearchResults(searchResult?.dictionary?.classes, query).map(({ bsddClass, matchedOn }) => ({
+        value: bsddClass.uri,
+        label: bsddClass.name,
+        code: bsddClass.referenceCode ?? undefined,
+        matchedOn,
+      })),
+    [searchResult, query],
+  );
 
   // Sync the draft text when the committed selection changes externally
   // (async seed resolution, reconciliation after a dictionary change).

--- a/src/lib/BsddSearch/Slicer.tsx
+++ b/src/lib/BsddSearch/Slicer.tsx
@@ -2,10 +2,13 @@ import { CheckIcon, CloseButton, Combobox, Group, InputBase, Loader, Paper, Text
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { SearchMatchedOn } from '../common/tools/rankClassSearchResults';
+
 interface Option {
   label: string;
   value: string;
   uri: string;
+  matchedOn?: SearchMatchedOn;
 }
 
 interface SlicerProps {
@@ -31,7 +34,6 @@ interface SlicerProps {
 
 const INITIAL_RENDER_LIMIT = 25;
 const RENDER_MORE_LIMIT = 25;
-const SEARCH_DEBOUNCE_MS = 300;
 
 function Slicer({
   height,
@@ -51,7 +53,6 @@ function Slicer({
   const [renderCount, setRenderCount] = useState(INITIAL_RENDER_LIMIT);
   const [disabled, setDisabled] = useState(loading || options.length === 1);
   const optionsContainerRef = useRef(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const combobox = useCombobox({
     onDropdownClose: () => {
@@ -91,23 +92,12 @@ function Slicer({
 
   const renderedOptions = filteredOptions.slice(0, renderCount);
 
+  // Debouncing lives with the server-search consumer (useDictionaryClassOptions)
   const handleSearchChange = (query: string) => {
     setSearch(query);
     setRenderCount(INITIAL_RENDER_LIMIT);
-    if (onSearch) {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => {
-        onSearch(query);
-      }, SEARCH_DEBOUNCE_MS);
-    }
+    onSearch?.(query);
   };
-
-  // Cleanup debounce on unmount
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, []);
 
   const handleScroll = (e: { currentTarget: { scrollTop: any; scrollHeight: any; clientHeight: any } }) => {
     const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
@@ -128,15 +118,20 @@ function Slicer({
   };
 
   const comboboxOptions = renderedOptions.map((item) => (
-    <Combobox.Option key={item.value} value={item.value} active={value?.value === item.value}>
+    <Combobox.Option key={item.uri} value={item.uri} active={value?.uri === item.uri}>
       <Group gap="sm">
-        {value?.value === item.value ? <CheckIcon size={12} /> : null}
+        {value?.uri === item.uri ? <CheckIcon size={12} /> : null}
         <Text fz="sm" opacity={disabled ? 0.6 : 1.0}>
           {item.label}
         </Text>
         <Text fz="xs" opacity={0.6}>
           ({item.value})
         </Text>
+        {item.matchedOn && (
+          <Text fz="xs" c="dimmed" fs="italic" ml="auto">
+            {item.matchedOn === 'synonym' ? t('matchedOnSynonym') : t('matchedOnDescription')}
+          </Text>
+        )}
       </Group>
     </Combobox.Option>
   ));
@@ -167,8 +162,8 @@ function Slicer({
         store={combobox}
         onOptionSubmit={(newValue) => {
           if (!disabled) {
-            const newOption = options.find((option) => option.value === newValue);
-            const newValueToSet = newOption && value?.value !== newOption.value ? newOption : null;
+            const newOption = options.find((option) => option.uri === newValue);
+            const newValueToSet = newOption && value?.uri !== newOption.uri ? newOption : null;
             setValue(newValueToSet);
             combobox.closeDropdown();
           }
@@ -189,6 +184,7 @@ function Slicer({
                   onClick={() => {
                     setSearch('');
                     setValue(null);
+                    onSearch?.('');
                   }}
                   aria-label="Clear value"
                 />

--- a/src/lib/BsddSearch/features/Classifications/Classifications.tsx
+++ b/src/lib/BsddSearch/features/Classifications/Classifications.tsx
@@ -1,50 +1,22 @@
 import { Box, Button, Paper, Tooltip } from '@mantine/core';
 import { IconGripHorizontal } from '@tabler/icons-react';
-import { useQueryClient } from '@tanstack/react-query';
-import { type MouseEventHandler, useEffect, useMemo, useRef, useState } from 'react';
+import { type MouseEventHandler, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useShallow } from 'zustand/react/shallow';
 
-import type {
-  ClassContractV1,
-  ClassListItemContractV1Classes,
-  DictionaryContractV1,
-} from '../../../../../shared/bsdd-api/generated/types.gen';
-import { CLASS_ITEM_PAGE_SIZE, fetchDictionaryClassesPage } from '../../../api/fetchers/dictionaries';
-import { searchInDictionary } from '../../../api/fetchers/search';
+import type { ClassContractV1, DictionaryContractV1 } from '../../../../../shared/bsdd-api/generated/types.gen';
 import { useDictionaries } from '../../../api/hooks/useDictionaries';
-import { bsddKeys } from '../../../api/queryKeys';
 import type { IfcClassification, IfcClassificationReference } from '../../../common/IfcData/ifc';
 import { useIfcDataStore } from '../../../stores/ifcDataStore';
 import { selectActiveDictionaries, selectMainDictionaryUri, useSettingsStore } from '../../../stores/settingsStore';
-import Slicer from '../../Slicer';
+import DictionarySlicer from './DictionarySlicer';
+import type { ClassOption } from './useDictionaryClassOptions';
 
 interface ClassificationsProps {
   height: number;
   handleMouseDown: MouseEventHandler<HTMLDivElement>;
   mainDictionaryClassification: ClassContractV1 | null;
 }
-
-interface Option {
-  label: string;
-  value: string;
-  uri: string;
-}
-
-interface BrowseState {
-  options: Option[];
-  nextOffset: number;
-  totalCount: number;
-}
-
-const toOptions = (classes: ClassListItemContractV1Classes[]): Option[] =>
-  classes
-    .filter((c) => c.uri && c.code)
-    .map((c) => ({
-      value: c.code as string,
-      label: c.name || '',
-      uri: c.uri as string,
-    }));
 
 /**
  * Converts a selected classification reference option to an IfcClassificationReference object.
@@ -56,7 +28,7 @@ const toOptions = (classes: ClassListItemContractV1Classes[]): Option[] =>
  */
 const convertToIfcClassificationReference = (
   dictionaryUri: string,
-  option: Option | null,
+  option: ClassOption | null,
   dictionaries: Record<string, DictionaryContractV1>,
 ): IfcClassificationReference | null => {
   if (!option || !option.value) return null;
@@ -79,7 +51,7 @@ const convertToIfcClassificationReference = (
   } as IfcClassificationReference;
 };
 
-const selectionsEqual = (a: Map<string, Option | null>, b: Map<string, Option | null>): boolean => {
+const selectionsEqual = (a: Map<string, ClassOption | null>, b: Map<string, ClassOption | null>): boolean => {
   if (a.size !== b.size) return false;
   for (const [key, optionA] of a) {
     if (!b.has(key)) return false;
@@ -92,17 +64,9 @@ const selectionsEqual = (a: Map<string, Option | null>, b: Map<string, Option | 
 };
 
 function Classifications({ height, handleMouseDown, mainDictionaryClassification }: ClassificationsProps) {
-  const queryClient = useQueryClient();
   const { t } = useTranslation();
-  const [optionsMap, setOptionsMap] = useState<Map<string, Option[]>>(new Map());
-  const [searchingDictionaries, setSearchingDictionaries] = useState<Set<string>>(new Set());
-  // Accumulated browse pages per `${dictionaryUri}|${languageCode}`, so paging
-  // survives effect re-runs and search-clear restores without refetching.
-  const browseStateRef = useRef<Map<string, BrowseState>>(new Map());
-  const loadingMoreRef = useRef<Set<string>>(new Set());
-  const [loadingMoreDictionaries, setLoadingMoreDictionaries] = useState<Set<string>>(new Set());
   const [selectedIfcClassificationReferences, setSelectedIfcClassificationReferences] = useState<
-    Map<string, Option | null>
+    Map<string, ClassOption | null>
   >(new Map());
 
   // Settings
@@ -113,7 +77,6 @@ function Classifications({ height, handleMouseDown, mainDictionaryClassification
   );
   const mainDictionaryUri = useSettingsStore(selectMainDictionaryUri);
   const includeTestDictionaries = useSettingsStore((s) => s.includeTestDictionaries);
-  const languageCode = useSettingsStore((s) => s.language);
 
   // IFC data
   // selectHasAssociationsMap builds a fresh object whose values are fresh arrays
@@ -141,10 +104,10 @@ function Classifications({ height, handleMouseDown, mainDictionaryClassification
 
   // Build dropdown options for each filter dictionary directly from the already-loaded
   // main class relations — no extra per-class fetches needed.
-  const groupedRelationOptions = useMemo((): Record<string, Option[]> => {
+  const groupedRelationOptions = useMemo((): Record<string, ClassOption[]> => {
     if (!mainDictionaryClassification) return {};
     const dictionaryUris = Array.from(activeDictionariesMap.keys());
-    const grouped: Record<string, Option[]> = {};
+    const grouped: Record<string, ClassOption[]> = {};
 
     const addOption = (classUri: string, className: string | null | undefined) => {
       // Find the active dictionary this class URI belongs to (longest prefix match)
@@ -168,118 +131,67 @@ function Classifications({ height, handleMouseDown, mainDictionaryClassification
     return grouped;
   }, [mainDictionaryClassification, activeDictionariesMap, mainDictionaryUri]);
 
-  // Build options map for each filter-dictionary slicer. The main dictionary has
-  // no slicer — the Search input is its editor — but its selection is pinned into
-  // the selections map below so it still reaches hasAssociations / Apply.
+  // Reconcile selections on a new main class: keep still-valid selections, fill
+  // only empty rows from the single-option / association seeds, clear only what
+  // no longer matches. The main dictionary has no slicer — the Search input is
+  // its editor — but its selection is pinned here so it still reaches
+  // hasAssociations / Apply. Relation-less single-class auto-selection lives in
+  // DictionarySlicer, which owns those options.
   useEffect(() => {
-    const updateOptionsMap = async () => {
-      const entries = Array.from(activeDictionariesMap.entries()).filter(([uri]) => uri !== mainDictionaryUri);
-      const optionsMapPromises = entries.map(async ([dictionaryUri]): Promise<[string, Option[]]> => {
-        let options: Option[] = [];
+    setSelectedIfcClassificationReferences((prev) => {
+      const next = new Map<string, ClassOption | null>();
+
+      if (mainDictionaryUri && mainDictionaryClassification) {
+        next.set(mainDictionaryUri, {
+          value: mainDictionaryClassification.code,
+          label: mainDictionaryClassification.name,
+          uri: mainDictionaryClassification.uri,
+        } as ClassOption);
+      }
+
+      for (const [dictionaryUri] of activeDictionariesMap) {
+        if (dictionaryUri === mainDictionaryUri) continue;
         const relationOptions = groupedRelationOptions[dictionaryUri];
+        const hasRelations = !!relationOptions?.length;
 
-        if (relationOptions && relationOptions.length > 0) {
-          // Options come directly from the main class relations — no fetch needed
-          options = relationOptions;
-        } else {
-          // No relations for this dictionary — page through classes on demand,
-          // starting with the first page as a searchable fallback
-          const browseKey = `${dictionaryUri}|${languageCode}`;
-          const browseState = browseStateRef.current.get(browseKey);
-          if (browseState) {
-            options = browseState.options;
-          } else {
-            try {
-              const page = await queryClient.fetchQuery({
-                queryKey: bsddKeys.dictionaryClassesPage(dictionaryUri, languageCode, 0),
-                queryFn: () => fetchDictionaryClassesPage(dictionaryUri, 0, languageCode),
-                staleTime: 1000 * 60 * 30,
-              });
-              options = toOptions(page.classes);
-              browseStateRef.current.set(browseKey, {
-                options,
-                nextOffset: CLASS_ITEM_PAGE_SIZE,
-                totalCount: page.totalCount,
-              });
-            } catch (error) {
-              console.error('Failed to fetch dictionary classes for', dictionaryUri, error);
-              options = [];
-            }
-          }
+        if (hasRelations && relationOptions.length === 1) {
+          next.set(dictionaryUri, relationOptions[0]);
+          continue;
         }
 
-        return [dictionaryUri, options];
-      });
-
-      const resolvedOptionsMap = await Promise.all(optionsMapPromises);
-      const newOptionsMap = new Map(resolvedOptionsMap);
-      setOptionsMap(newOptionsMap);
-
-      // Reconcile instead of rebuilding: keep still-valid selections, fill only
-      // empty rows from the single-option / association seeds, clear only what no
-      // longer matches the new main class.
-      setSelectedIfcClassificationReferences((prev) => {
-        const next = new Map<string, Option | null>();
-
-        if (mainDictionaryUri && mainDictionaryClassification) {
-          next.set(mainDictionaryUri, {
-            value: mainDictionaryClassification.code,
-            label: mainDictionaryClassification.name,
-            uri: mainDictionaryClassification.uri,
-          } as Option);
+        const previous = prev.get(dictionaryUri);
+        if (previous) {
+          // Relation-less rows don't depend on the main class — never invalidated
+          // by it. Relation-backed rows survive iff still among the new options.
+          if (!hasRelations || relationOptions.some((option) => option.uri === previous.uri)) {
+            next.set(dictionaryUri, previous);
+            continue;
+          }
+        } else if (prev.has(dictionaryUri)) {
+          // Explicitly cleared by the user — seeding must not refill it
+          next.set(dictionaryUri, null);
+          continue;
         }
 
-        newOptionsMap.forEach((options, dictionaryUri) => {
-          if (options.length === 1) {
-            next.set(dictionaryUri, options[0]);
-            return;
+        const dictionaryAssociations = hasAssociations[dictionaryUri];
+        if (dictionaryAssociations?.length === 1) {
+          const dictionaryAssociation = dictionaryAssociations[0];
+          const isValidOption =
+            !hasRelations || relationOptions.some((option) => option.value === dictionaryAssociation.identification);
+
+          if (isValidOption) {
+            next.set(dictionaryUri, {
+              label: dictionaryAssociation.name || '',
+              value: dictionaryAssociation.identification || '',
+              uri: dictionaryAssociation.location || '',
+            });
           }
+        }
+      }
 
-          const hasRelations = !!groupedRelationOptions[dictionaryUri]?.length;
-          const previous = prev.get(dictionaryUri);
-          if (previous) {
-            // Relation-less rows don't depend on the main class — never invalidated
-            // by it. Relation-backed rows survive iff still among the new options.
-            if (!hasRelations || options.some((option) => option.uri === previous.uri)) {
-              next.set(dictionaryUri, previous);
-              return;
-            }
-          } else if (prev.has(dictionaryUri)) {
-            // Explicitly cleared by the user — seeding must not refill it
-            next.set(dictionaryUri, null);
-            return;
-          }
-
-          const dictionaryAssociations = hasAssociations[dictionaryUri];
-          if (dictionaryAssociations?.length === 1) {
-            const dictionaryAssociation = dictionaryAssociations[0];
-            const isValidOption =
-              !hasRelations || options.some((option) => option.value === dictionaryAssociation.identification);
-
-            if (isValidOption) {
-              next.set(dictionaryUri, {
-                label: dictionaryAssociation.name || '',
-                value: dictionaryAssociation.identification || '',
-                uri: dictionaryAssociation.location || '',
-              });
-            }
-          }
-        });
-
-        return selectionsEqual(prev, next) ? prev : next;
-      });
-    };
-
-    updateOptionsMap();
-  }, [
-    activeDictionariesMap,
-    groupedRelationOptions,
-    queryClient,
-    languageCode,
-    hasAssociations,
-    mainDictionaryClassification,
-    mainDictionaryUri,
-  ]);
+      return selectionsEqual(prev, next) ? prev : next;
+    });
+  }, [activeDictionariesMap, groupedRelationOptions, hasAssociations, mainDictionaryClassification, mainDictionaryUri]);
 
   // Update associations when selections change
   useEffect(() => {
@@ -292,139 +204,24 @@ function Classifications({ height, handleMouseDown, mainDictionaryClassification
     }
   }, [dictionariesMap, selectedIfcClassificationReferences, setHasAssociations]);
 
-  // Dictionaries without class relations need server-side search in the slicer
-  const dictionariesWithoutRelations = useMemo(() => {
-    const set = new Set<string>();
-    for (const [dictionaryUri] of activeDictionariesMap.entries()) {
-      if (dictionaryUri === mainDictionaryUri) continue;
-      if (!groupedRelationOptions[dictionaryUri]?.length) {
-        set.add(dictionaryUri);
-      }
-    }
-    return set;
-  }, [activeDictionariesMap, groupedRelationOptions, mainDictionaryUri]);
-
-  // Server-side search for filter dictionaries without relations
-  const handleSlicerSearch = async (dictionaryUri: string, query: string) => {
-    if (!query.trim()) {
-      // Search cleared — restore the accumulated browse list
-      const browseKey = `${dictionaryUri}|${languageCode}`;
-      const browseState = browseStateRef.current.get(browseKey);
-      if (browseState) {
-        setOptionsMap((prev) => new Map(prev).set(dictionaryUri, browseState.options));
-        return;
-      }
-      try {
-        const page = await queryClient.fetchQuery({
-          queryKey: bsddKeys.dictionaryClassesPage(dictionaryUri, languageCode, 0),
-          queryFn: () => fetchDictionaryClassesPage(dictionaryUri, 0, languageCode),
-          staleTime: 1000 * 60 * 30,
-        });
-        const options = toOptions(page.classes);
-        browseStateRef.current.set(browseKey, {
-          options,
-          nextOffset: CLASS_ITEM_PAGE_SIZE,
-          totalCount: page.totalCount,
-        });
-        setOptionsMap((prev) => new Map(prev).set(dictionaryUri, options));
-      } catch {
-        /* keep existing options */
-      }
-      return;
-    }
-
-    setSearchingDictionaries((prev) => new Set(prev).add(dictionaryUri));
-    try {
-      const result = await searchInDictionary({
-        DictionaryUri: dictionaryUri,
-        SearchText: query,
-        languageCode: languageCode,
-      });
-      const options: Option[] = (result.dictionary?.classes ?? [])
-        .filter((c) => c.uri && c.referenceCode)
-        .map((c) => ({
-          value: c.referenceCode as string,
-          label: c.name || '',
-          uri: c.uri as string,
-        }));
-      setOptionsMap((prev) => new Map(prev).set(dictionaryUri, options));
-    } catch (error) {
-      console.error('Search failed for', dictionaryUri, error);
-    } finally {
-      setSearchingDictionaries((prev) => {
-        const next = new Set(prev);
-        next.delete(dictionaryUri);
-        return next;
-      });
-    }
-  };
-
-  // Fetch the next page of classes when the slicer scrolls past the loaded set
-  const handleSlicerLoadMore = async (dictionaryUri: string) => {
-    const browseKey = `${dictionaryUri}|${languageCode}`;
-    const browseState = browseStateRef.current.get(browseKey);
-    if (!browseState || browseState.nextOffset >= browseState.totalCount) return;
-    if (loadingMoreRef.current.has(browseKey)) return;
-    loadingMoreRef.current.add(browseKey);
-    setLoadingMoreDictionaries((prev) => new Set(prev).add(dictionaryUri));
-    try {
-      const offset = browseState.nextOffset;
-      const page = await queryClient.fetchQuery({
-        queryKey: bsddKeys.dictionaryClassesPage(dictionaryUri, languageCode, offset),
-        queryFn: () => fetchDictionaryClassesPage(dictionaryUri, offset, languageCode),
-        staleTime: 1000 * 60 * 30,
-      });
-      const updated: BrowseState = {
-        options: [...browseState.options, ...toOptions(page.classes)],
-        nextOffset: offset + CLASS_ITEM_PAGE_SIZE,
-        totalCount: page.totalCount,
-      };
-      browseStateRef.current.set(browseKey, updated);
-      setOptionsMap((prev) => new Map(prev).set(dictionaryUri, updated.options));
-    } catch (error) {
-      console.error('Failed to fetch more dictionary classes for', dictionaryUri, error);
-    } finally {
-      loadingMoreRef.current.delete(browseKey);
-      setLoadingMoreDictionaries((prev) => {
-        const next = new Set(prev);
-        next.delete(dictionaryUri);
-        return next;
-      });
-    }
-  };
-
   return (
     <Paper style={{ height: `${height}px`, position: 'relative' }}>
       {Array.from(activeDictionariesMap.entries())
         .filter(([dictionaryUri]) => dictionaryUri !== mainDictionaryUri)
-        .map(([dictionaryUri, dictionary]) => {
-          const handleSetValue = (newValue: Option | null) => {
-            setSelectedIfcClassificationReferences((prev) => new Map(prev).set(dictionaryUri, newValue));
-          };
-
-          return (
-            <Slicer
-              key={dictionaryUri}
-              height={height}
-              label={dictionary.name}
-              options={optionsMap.get(dictionaryUri) || []}
-              value={selectedIfcClassificationReferences.get(dictionaryUri) || null}
-              setValue={handleSetValue}
-              placeholder={t('classifications.searchClassesPlaceholder')}
-              onSearch={
-                dictionariesWithoutRelations.has(dictionaryUri)
-                  ? (query) => handleSlicerSearch(dictionaryUri, query)
-                  : undefined
-              }
-              isSearching={searchingDictionaries.has(dictionaryUri)}
-              onLoadMore={
-                dictionariesWithoutRelations.has(dictionaryUri) ? () => handleSlicerLoadMore(dictionaryUri) : undefined
-              }
-              isLoadingMore={loadingMoreDictionaries.has(dictionaryUri)}
-              loading={!mainDictionaryClassification}
-            />
-          );
-        })}
+        .map(([dictionaryUri, dictionary]) => (
+          <DictionarySlicer
+            key={dictionaryUri}
+            height={height}
+            dictionaryUri={dictionaryUri}
+            label={dictionary.name}
+            relationOptions={groupedRelationOptions[dictionaryUri]}
+            value={selectedIfcClassificationReferences.get(dictionaryUri) || null}
+            setValue={(newValue) =>
+              setSelectedIfcClassificationReferences((prev) => new Map(prev).set(dictionaryUri, newValue))
+            }
+            loading={!mainDictionaryClassification}
+          />
+        ))}
       <Box onMouseDown={handleMouseDown} style={{ marginTop: '4px' }}>
         <Tooltip label={t('classifications.dragResize')} withArrow>
           <Button fullWidth variant="subtle" size="sm" color="gray" aria-label={t('classifications.dragResize')}>

--- a/src/lib/BsddSearch/features/Classifications/DictionarySlicer.tsx
+++ b/src/lib/BsddSearch/features/Classifications/DictionarySlicer.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Slicer from '../../Slicer';
+import { type ClassOption, useDictionaryClassOptions } from './useDictionaryClassOptions';
+
+interface DictionarySlicerProps {
+  height: number;
+  dictionaryUri: string;
+  label: string | undefined;
+  /** Options derived from the main class relations; when present, no fetching is needed */
+  relationOptions: ClassOption[] | undefined;
+  value: ClassOption | null;
+  setValue: (newValue: ClassOption | null) => void;
+  loading: boolean;
+}
+
+function DictionarySlicer({
+  height,
+  dictionaryUri,
+  label,
+  relationOptions,
+  value,
+  setValue,
+  loading,
+}: DictionarySlicerProps) {
+  const { t } = useTranslation();
+  const hasRelations = !!relationOptions?.length;
+  const [searchText, setSearchText] = useState('');
+  const {
+    options: fetchedOptions,
+    serverSearch,
+    isSearching,
+    loadMore,
+    isLoadingMore,
+  } = useDictionaryClassOptions(dictionaryUri, searchText, !hasRelations);
+
+  const options = hasRelations ? (relationOptions as ClassOption[]) : fetchedOptions;
+
+  // Relation-backed single options are auto-selected during reconciliation in
+  // Classifications; a relation-less dictionary with a single class is seeded
+  // here. Never from search results — those are a filtered subset.
+  useEffect(() => {
+    if (!hasRelations && !searchText && options.length === 1 && !value) setValue(options[0]);
+  }, [hasRelations, searchText, options, value, setValue]);
+
+  return (
+    <Slicer
+      height={height}
+      label={label}
+      options={options}
+      value={value}
+      setValue={setValue}
+      placeholder={t('classifications.searchClassesPlaceholder')}
+      onSearch={serverSearch ? setSearchText : undefined}
+      isSearching={isSearching}
+      onLoadMore={serverSearch ? loadMore : undefined}
+      isLoadingMore={isLoadingMore}
+      loading={loading}
+    />
+  );
+}
+
+export default DictionarySlicer;

--- a/src/lib/BsddSearch/features/Classifications/useDictionaryClassOptions.ts
+++ b/src/lib/BsddSearch/features/Classifications/useDictionaryClassOptions.ts
@@ -8,7 +8,7 @@
 //    dictionaries, ranked because the endpoint also matches synonyms and
 //    descriptions but returns hits alphabetically.
 import { useDebouncedValue } from '@mantine/hooks';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 
 import type { ClassListItemContractV1Classes } from '../../../../../shared/bsdd-api/generated/types.gen';
@@ -45,8 +45,15 @@ export const toOptions = (classes: ClassListItemContractV1Classes[]): ClassOptio
     }));
 
 export function useDictionaryClassOptions(dictionaryUri: string, searchText: string, enabled: boolean) {
+  const queryClient = useQueryClient();
   const languageCode = useSettingsStore((s) => s.language);
   const [debouncedSearchText] = useDebouncedValue(searchText, SEARCH_DEBOUNCE_MS);
+
+  // Skip even the first browse page when the complete list is already cached
+  // (validation flow, or a restored persister snapshot). Re-evaluated on every
+  // render; the fullListQuery observer below triggers one when the list lands.
+  const hasCachedFullList =
+    queryClient.getQueryData(bsddKeys.dictionaryClasses(dictionaryUri, languageCode)) !== undefined;
 
   const browseQuery = useInfiniteQuery({
     queryKey: bsddKeys.dictionaryClassesInfinite(dictionaryUri, languageCode),
@@ -55,7 +62,7 @@ export function useDictionaryClassOptions(dictionaryUri: string, searchText: str
     getNextPageParam: (lastPage, _pages, lastOffset) =>
       lastOffset + CLASS_ITEM_PAGE_SIZE < lastPage.totalCount ? lastOffset + CLASS_ITEM_PAGE_SIZE : undefined,
     staleTime: 1000 * 60 * 30,
-    enabled,
+    enabled: enabled && !hasCachedFullList,
   });
 
   const totalCount = browseQuery.data?.pages[0]?.totalCount;

--- a/src/lib/BsddSearch/features/Classifications/useDictionaryClassOptions.ts
+++ b/src/lib/BsddSearch/features/Classifications/useDictionaryClassOptions.ts
@@ -1,0 +1,119 @@
+// Purpose: class options for a relation-less filter-dictionary slicer.
+// Three modes, resolved declaratively per render:
+// 1. Full list — small dictionaries load completely (≤5 paged calls, persisted
+//    24h), large ones ride on a list the validation flow already cached.
+//    Filtering then happens client-side in the Slicer: instant and free.
+// 2. Browse — infinite paging through Dictionary/v1/Classes while scrolling.
+// 3. Server search — debounced SearchInDictionary for large, uncached
+//    dictionaries, ranked because the endpoint also matches synonyms and
+//    descriptions but returns hits alphabetically.
+import { useDebouncedValue } from '@mantine/hooks';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+
+import type { ClassListItemContractV1Classes } from '../../../../../shared/bsdd-api/generated/types.gen';
+import {
+  CLASS_ITEM_PAGE_SIZE,
+  fetchAllDictionaryClasses,
+  fetchDictionaryClassesPage,
+} from '../../../api/fetchers/dictionaries';
+import { searchInDictionary } from '../../../api/fetchers/search';
+import { bsddKeys } from '../../../api/queryKeys';
+import { type SearchMatchedOn, rankClassSearchResults } from '../../../common/tools/rankClassSearchResults';
+import { useSettingsStore } from '../../../stores/settingsStore';
+
+export interface ClassOption {
+  label: string;
+  value: string;
+  uri: string;
+  matchedOn?: SearchMatchedOn;
+}
+
+// Up to 5 paged calls (one anonymous burst window) — a bound on how long a
+// background load may shadow interactive calls in the FIFO transport queue,
+// not on the rate budget. Dictionaries above this keep server-side search.
+const FULL_LOAD_MAX_CLASSES = 2500;
+const SEARCH_DEBOUNCE_MS = 300;
+
+export const toOptions = (classes: ClassListItemContractV1Classes[]): ClassOption[] =>
+  classes
+    .filter((c) => c.uri && c.code)
+    .map((c) => ({
+      value: c.code as string,
+      label: c.name || '',
+      uri: c.uri as string,
+    }));
+
+export function useDictionaryClassOptions(dictionaryUri: string, searchText: string, enabled: boolean) {
+  const languageCode = useSettingsStore((s) => s.language);
+  const [debouncedSearchText] = useDebouncedValue(searchText, SEARCH_DEBOUNCE_MS);
+
+  const browseQuery = useInfiniteQuery({
+    queryKey: bsddKeys.dictionaryClassesInfinite(dictionaryUri, languageCode),
+    queryFn: ({ pageParam }) => fetchDictionaryClassesPage(dictionaryUri, pageParam, languageCode),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _pages, lastOffset) =>
+      lastOffset + CLASS_ITEM_PAGE_SIZE < lastPage.totalCount ? lastOffset + CLASS_ITEM_PAGE_SIZE : undefined,
+    staleTime: 1000 * 60 * 30,
+    enabled,
+  });
+
+  const totalCount = browseQuery.data?.pages[0]?.totalCount;
+
+  // Disabled query observers still surface cached data, so when validation (or
+  // a previous session via the IndexedDB persister) already paid for the
+  // complete list, even large dictionaries get it for free. The long staleTime
+  // keeps a restored list from triggering a surprise multi-call refetch.
+  const fullListQuery = useQuery({
+    queryKey: bsddKeys.dictionaryClasses(dictionaryUri, languageCode),
+    queryFn: () => fetchAllDictionaryClasses(dictionaryUri, languageCode),
+    staleTime: 1000 * 60 * 60 * 24,
+    enabled: enabled && totalCount !== undefined && totalCount <= FULL_LOAD_MAX_CLASSES,
+  });
+
+  const browseComplete = browseQuery.data !== undefined && !browseQuery.hasNextPage;
+  const fullyLoaded = fullListQuery.data !== undefined || browseComplete;
+  const serverSearch = enabled && !fullyLoaded;
+
+  const trimmedSearch = debouncedSearchText.trim();
+  const searchActive = serverSearch && trimmedSearch.length > 0;
+  const searchQuery = useQuery({
+    queryKey: bsddKeys.search(dictionaryUri, trimmedSearch, languageCode),
+    queryFn: () => searchInDictionary({ DictionaryUri: dictionaryUri, SearchText: trimmedSearch, languageCode }),
+    staleTime: 1000 * 60 * 5,
+    enabled: searchActive,
+  });
+
+  const options = useMemo<ClassOption[]>(() => {
+    if (!enabled) return [];
+    if (fullListQuery.data) return toOptions(fullListQuery.data);
+    if (searchActive) {
+      if (!searchQuery.data) return [];
+      return rankClassSearchResults(searchQuery.data.dictionary?.classes, trimmedSearch).map(
+        ({ bsddClass, matchedOn }) => ({
+          // Code = referenceCode when published, else the URI's last path segment
+          value: bsddClass.referenceCode ?? bsddClass.uri.split('/').filter(Boolean).pop() ?? bsddClass.uri,
+          label: bsddClass.name,
+          uri: bsddClass.uri,
+          matchedOn,
+        }),
+      );
+    }
+    return toOptions(browseQuery.data?.pages.flatMap((page) => page.classes) ?? []);
+  }, [enabled, fullListQuery.data, searchActive, searchQuery.data, trimmedSearch, browseQuery.data]);
+
+  const { fetchNextPage, hasNextPage, isFetchingNextPage } = browseQuery;
+  const loadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  return {
+    options,
+    serverSearch,
+    // Covers the debounce window too, so the stale browse list never poses as a result
+    isSearching:
+      serverSearch && searchText.trim().length > 0 && (searchText.trim() !== trimmedSearch || searchQuery.isPending),
+    loadMore,
+    isLoadingMore: isFetchingNextPage,
+  };
+}

--- a/src/lib/api/queryKeys.test.ts
+++ b/src/lib/api/queryKeys.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { bsddKeys } from './queryKeys';
+import { bsddKeys, isPersistableQueryKey } from './queryKeys';
 
 describe('bsddKeys', () => {
   it('shares the "bsdd" namespace prefix on every key', () => {
@@ -23,5 +23,23 @@ describe('bsddKeys', () => {
     expect(bsddKeys.dictionary('a')).not.toEqual(bsddKeys.dictionary('b'));
     expect(bsddKeys.dictionaries(true)).not.toEqual(bsddKeys.dictionaries(false));
     expect(bsddKeys.dictionaryClasses('uri', 'en')).not.toEqual(bsddKeys.dictionaryClasses('uri', 'nl'));
+    expect(bsddKeys.search('uri', 'q', 'en')).not.toEqual(bsddKeys.search('uri', 'q', 'nl'));
+    expect(bsddKeys.search('uri', 'q', 'en')).not.toEqual(bsddKeys.search('uri', 'q'));
+  });
+});
+
+describe('isPersistableQueryKey', () => {
+  it('excludes ephemeral search results from persistence', () => {
+    expect(isPersistableQueryKey(bsddKeys.search('uri', 'q'))).toBe(false);
+    expect(isPersistableQueryKey(bsddKeys.search('uri', 'q', 'en'))).toBe(false);
+  });
+
+  it('keeps everything else persistable', () => {
+    expect(isPersistableQueryKey(bsddKeys.dictionaries(false))).toBe(true);
+    expect(isPersistableQueryKey(bsddKeys.dictionary('uri'))).toBe(true);
+    expect(isPersistableQueryKey(bsddKeys.dictionaryClasses('uri', 'en'))).toBe(true);
+    expect(isPersistableQueryKey(bsddKeys.dictionaryClassesInfinite('uri', 'en'))).toBe(true);
+    expect(isPersistableQueryKey(bsddKeys.classDetails('uri', 'en'))).toBe(true);
+    expect(isPersistableQueryKey(bsddKeys.propertyName('uri', 'en'))).toBe(true);
   });
 });

--- a/src/lib/api/queryKeys.ts
+++ b/src/lib/api/queryKeys.ts
@@ -3,11 +3,17 @@ export const bsddKeys = {
   dictionaries: (includeTest?: boolean) => [...bsddKeys.all, 'dictionaries', { includeTest }] as const,
   dictionary: (uri: string) => [...bsddKeys.all, 'dictionary', uri] as const,
   dictionaryClasses: (uri: string, lang: string) => [...bsddKeys.all, 'dictionaryClasses', uri, lang] as const,
-  dictionaryClassesPage: (uri: string, lang: string, offset: number) =>
-    [...bsddKeys.dictionaryClasses(uri, lang), 'page', offset] as const,
+  dictionaryClassesInfinite: (uri: string, lang: string) =>
+    [...bsddKeys.dictionaryClasses(uri, lang), 'infinite'] as const,
   classDetails: (uri: string, lang: string, filterUris: string[] = []) =>
     [...bsddKeys.all, 'classDetails', uri, lang, [...filterUris].sort()] as const,
   classes: (uris: string[], lang: string) => [...bsddKeys.all, 'classes', uris, lang] as const,
-  search: (dictUri: string, searchText: string) => [...bsddKeys.all, 'search', dictUri, searchText] as const,
+  search: (dictUri: string, searchText: string, lang?: string) =>
+    [...bsddKeys.all, 'search', dictUri, searchText, { lang }] as const,
   propertyName: (uri: string, lang: string) => [...bsddKeys.all, 'propertyName', uri, lang] as const,
 } as const;
+
+// Search results are ephemeral (5 min staleTime) — persisting them only bloats
+// the IndexedDB snapshot that gets rewritten on every cache change while the
+// user types, and slows the restore on each window boot.
+export const isPersistableQueryKey = (queryKey: readonly unknown[]): boolean => queryKey[1] !== 'search';

--- a/src/lib/common/tools/rankClassSearchResults.ts
+++ b/src/lib/common/tools/rankClassSearchResults.ts
@@ -1,0 +1,41 @@
+// Purpose: shared ranking for bSDD SearchInDictionary results. The endpoint
+// matches names, codes, synonyms and descriptions but returns hits
+// alphabetically, so indirect matches must be ranked down and tagged with why
+// they matched.
+import type { ClassSearchResultContractV1 } from '../../../../shared/bsdd-api/generated/types.gen';
+
+export type SearchMatchedOn = 'synonym' | 'description';
+
+export interface RankedClassSearchResult {
+  bsddClass: ClassSearchResultContractV1 & { uri: string; name: string };
+  matchedOn?: SearchMatchedOn;
+}
+
+export function rankClassSearchResults(
+  classes: ClassSearchResultContractV1[] | null | undefined,
+  query: string,
+): RankedClassSearchResult[] {
+  const lcQuery = query.toLowerCase();
+  const ranked = (classes ?? [])
+    .filter((c): c is RankedClassSearchResult['bsddClass'] => !!(c.uri && c.name))
+    .map((bsddClass) => {
+      const name = bsddClass.name.toLowerCase();
+      const code = bsddClass.referenceCode?.toLowerCase() ?? '';
+      let tier: number;
+      let matchedOn: SearchMatchedOn | undefined;
+      if (name === lcQuery) tier = 0;
+      else if (name.startsWith(lcQuery)) tier = 1;
+      else if (name.includes(lcQuery)) tier = 2;
+      else if (code.includes(lcQuery)) tier = 3;
+      else if (bsddClass.synonyms?.some((s) => s.toLowerCase().includes(lcQuery))) {
+        tier = 4;
+        matchedOn = 'synonym';
+      } else {
+        tier = 5;
+        if (bsddClass.definition?.toLowerCase().includes(lcQuery)) matchedOn = 'description';
+      }
+      return { tier, result: { bsddClass, matchedOn } };
+    });
+  ranked.sort((a, b) => a.tier - b.tier || a.result.bsddClass.name.localeCompare(b.result.bsddClass.name));
+  return ranked.map((r) => r.result);
+}

--- a/src/lib/providers/BsddProvider.tsx
+++ b/src/lib/providers/BsddProvider.tsx
@@ -2,12 +2,13 @@ import '@mantine/core/styles.css';
 import 'mantine-react-table/styles.css';
 
 import { MantineProvider } from '@mantine/core';
-import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
+import { type PersistQueryClientOptions, PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import { type ReactNode, Suspense, useEffect, useMemo } from 'react';
 
 import { setBsddAccessToken } from '../api/bsddApiInstance';
 import { bsddPersister } from '../api/persister';
 import { createBsddQueryClient } from '../api/queryClient';
+import { isPersistableQueryKey } from '../api/queryKeys';
 import type { BsddBridgeData, BsddSettings } from '../common/IfcData/bsddBridgeData';
 import type { IfcEntity } from '../common/IfcData/ifc';
 import i18n from '../common/i18n';
@@ -62,7 +63,18 @@ export function BsddProvider({
   children,
 }: BsddProviderProps) {
   const queryClient = useMemo(() => createBsddQueryClient(), []);
-  const persistOptions = useMemo(() => ({ persister: bsddPersister, maxAge: 1000 * 60 * 60 * 24 }), []);
+  const persistOptions = useMemo<Omit<PersistQueryClientOptions, 'queryClient'>>(
+    () => ({
+      persister: bsddPersister,
+      maxAge: 1000 * 60 * 60 * 24,
+      dehydrateOptions: {
+        // status check = defaultShouldDehydrateQuery, inlined because the
+        // persist-client's nested query-core copy makes the import type-incompatible
+        shouldDehydrateQuery: (query) => query.state.status === 'success' && isPersistableQueryKey(query.queryKey),
+      },
+    }),
+    [],
+  );
 
   useI18nLanguageSubscription();
 


### PR DESCRIPTION
## Problem

Typing in a filter-dictionary slicer gave weird results (#fixed previously in the main search, but not here):

- The slicer routed typed input to `SearchInDictionary`, which matches synonyms/descriptions and returns hits **alphabetically** — indirect matches showed unranked and unexplained.
- Search results with a null `referenceCode` were dropped entirely, so some queries returned "Nothing found" for classes that exist.
- No out-of-order guard: a slow response for a stale query could overwrite newer results.
- Scrolling (paged browse) worked fine — the two paths just behaved completely differently.

## Approach

**Hybrid by dictionary size**, decided with the `totalCount` we already get from the first page:

- **≤ 2500 classes** (IFC-scale): load the full list once (≤5 paged calls ≈ one anonymous burst window, persisted 24h in IndexedDB), then filter client-side — instant and free. The threshold is a *FIFO-queue contention* bound, not a rate bound.
- **Larger** (ETIM ~6k, Uniclass 14k+): keep debounced server search, now ranked with the same tier logic as the main search (shared helper `rankClassSearchResults`) incl. the *synonym/description* match tags.
- **Validation rider:** a disabled query observer on `bsddKeys.dictionaryClasses` picks up the complete lists the validation flow already caches. In the Revit workflow (long-lived Selection window persists on every selection; each Search window boots fresh and restores the snapshot) this means even Uniclass-scale dictionaries filter client-side at zero extra calls.

## Refactor

`Classifications.tsx` (470 → ~240 lines) no longer contains fetch logic. The hand-rolled machinery — browse-state ref, in-flight refs, race-guard seq map, three state sets — is replaced by:

- `useDictionaryClassOptions` — one hook, three declarative modes on `useInfiniteQuery`/`useQuery`; key-per-query-string makes race guards unnecessary.
- `DictionarySlicer` — per-dictionary wrapper owning its search text and single-class auto-select.
- `Slicer` is purely presentational again (debounce moved to the hook); its clear button now also resets the parent search text (pre-existing stale-results bug).
- Option identity is the canonical class **URI**, so the same class selected via search vs. browse matches.

## Persister

Search results (5-min staleTime) are excluded from dehydration: typing no longer rewrites the multi-MB IndexedDB snapshot once per second, and each Search-window boot restores a smaller blob.

## Testing

- `yarn tsc --noEmit`, `yarn test` (57/57), `yarn lint` (at pre-existing baseline) all pass.
- Manual check suggested: a relation-less small dictionary (full-load path) and a Uniclass-scale one (server search path) in `yarn dev`.